### PR TITLE
Feature: SegmentGroup 컴포넌트 구현

### DIFF
--- a/src/components/SegmentGroup/SegmentGroup.client.tsx
+++ b/src/components/SegmentGroup/SegmentGroup.client.tsx
@@ -1,0 +1,107 @@
+'use client';
+import cn from '@/utils/cn';
+import {
+  Children,
+  type ReactElement,
+  cloneElement,
+  createContext,
+  isValidElement,
+  useContext,
+} from 'react';
+
+import type { StrictPropsWithChildren } from '@/types';
+
+type ValueType = string | number | null;
+
+// 선택된 Segment의 border를 없애기 위한 로직
+function renderElements(elements: ReactElement[], selectedValue?: ValueType) {
+  return elements.map((element, index) => {
+    if (index === elements.length - 1) {
+      return cloneElement(element, {
+        className: cn('border-none', element.props.className),
+      });
+    }
+    if (elements[index + 1].props.value === selectedValue) {
+      return cloneElement(element, {
+        className: cn('border-none', element.props.className),
+      });
+    }
+    return element;
+  });
+}
+
+type SegmentContextValue<T = any> = {
+  selectedValue?: T;
+  onChange: (selectedValue: T) => void;
+};
+
+const SegmentContext = createContext<SegmentContextValue | null>(null);
+
+interface SegmentGroupProps<T extends ValueType> {
+  selectedValue?: T;
+  onChange: (selectedValue: T) => void;
+}
+
+function SegmentGroup<T extends ValueType>({
+  selectedValue,
+  onChange,
+  children,
+}: StrictPropsWithChildren<SegmentGroupProps<T>>) {
+  const validChildren = Children.toArray(children).filter(
+    (child) =>
+      isValidElement(child) &&
+      (
+        child.type as {
+          name: string;
+        }
+      ).name === 'Segment'
+  ) as ReactElement[];
+
+  if (validChildren.length === 0) {
+    throw new Error('SegmentGroup은 하나 이상의 Segment를 포함해야 합니다.');
+  }
+
+  return (
+    <SegmentContext.Provider
+      value={{
+        selectedValue,
+        onChange,
+      }}
+    >
+      <div className="flex overflow-hidden rounded-8 border border-border-default">
+        {renderElements(validChildren, selectedValue)}
+      </div>
+    </SegmentContext.Provider>
+  );
+}
+
+interface SegmentProps<T extends ValueType> {
+  label: string;
+  value: T;
+  className?: string;
+}
+
+// TODO: selectedValue의 타입이 추론되도록 수정
+function Segment<T extends ValueType>({ label, value, className }: SegmentProps<T>) {
+  const { onChange, selectedValue } = useContext(SegmentContext)!;
+
+  const isSelected = selectedValue === value;
+
+  return (
+    <button
+      className={cn(
+        'flex-grow p-16 text-subtitle-2',
+        {
+          ' bg-primary text-sign-white': isSelected,
+          'border-r-1 border-border-default bg-white text-subtitle-2': !isSelected,
+        },
+        className
+      )}
+      onClick={() => onChange(value)}
+    >
+      {label}
+    </button>
+  );
+}
+
+export default Object.assign(SegmentGroup, { Segment });

--- a/src/components/SegmentGroup/SegmentGroup.client.tsx
+++ b/src/components/SegmentGroup/SegmentGroup.client.tsx
@@ -40,7 +40,13 @@ const SegmentContext = createContext<SegmentContextValue | null>(null);
 
 interface SegmentGroupProps<T extends ValueType>
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  /**
+   * 선택된 Segment의 value입니다.
+   */
   selectedValue?: T;
+  /**
+   * Segment를 선택했을 때 호출되는 함수입니다.
+   */
   onChange: (selectedValue: T) => void;
 }
 
@@ -83,8 +89,17 @@ function SegmentGroup<T extends ValueType>({
 }
 
 interface SegmentProps<T extends ValueType> {
+  /**
+   * 세그먼트에 보여질 라벨입니다.
+   */
   label: string;
+  /**
+   * 세그먼트의 value입니다.
+   */
   value: T;
+  /**
+   * 클래스를 
+   */
   className?: string;
 }
 

--- a/src/components/SegmentGroup/SegmentGroup.client.tsx
+++ b/src/components/SegmentGroup/SegmentGroup.client.tsx
@@ -98,7 +98,7 @@ interface SegmentProps<T extends ValueType> {
    */
   value: T;
   /**
-   * 클래스를 
+   * 클래스를 추가할 수 있습니다.
    */
   className?: string;
 }

--- a/src/components/SegmentGroup/SegmentGroup.client.tsx
+++ b/src/components/SegmentGroup/SegmentGroup.client.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import cn from '@/utils/cn';
 import {
   Children,
@@ -37,7 +38,8 @@ type SegmentContextValue<T = any> = {
 
 const SegmentContext = createContext<SegmentContextValue | null>(null);
 
-interface SegmentGroupProps<T extends ValueType> {
+interface SegmentGroupProps<T extends ValueType>
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
   selectedValue?: T;
   onChange: (selectedValue: T) => void;
 }
@@ -45,7 +47,9 @@ interface SegmentGroupProps<T extends ValueType> {
 function SegmentGroup<T extends ValueType>({
   selectedValue,
   onChange,
+  className,
   children,
+  ...props
 }: StrictPropsWithChildren<SegmentGroupProps<T>>) {
   const validChildren = Children.toArray(children).filter(
     (child) =>
@@ -68,7 +72,10 @@ function SegmentGroup<T extends ValueType>({
         onChange,
       }}
     >
-      <div className="flex overflow-hidden rounded-8 border border-border-default">
+      <div
+        className={cn('flex overflow-hidden rounded-8 border border-border-default', className)}
+        {...props}
+      >
         {renderElements(validChildren, selectedValue)}
       </div>
     </SegmentContext.Provider>

--- a/src/components/SegmentGroup/index.ts
+++ b/src/components/SegmentGroup/index.ts
@@ -1,0 +1,1 @@
+export { default as SegmentGroup } from './SegmentGroup.client';


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 신규 피처
- close #193

## 💁 무엇이 어떻게 바뀌나요?

1. SegmentGroup 컴포넌트를 구현했습니다.

## 용례

```tsx
  type Gender = 'MALE' | 'FEMALE';

  const [selectedValue, setSelectedValue] = useState<Gender | null>(null);

  return (
    <SegmentGroup selectedValue={selectedValue} onChange={(value) => setSelectedValue(value)}>
      <SegmentGroup.Segment value={'MALE'} label="남성" />
      <SegmentGroup.Segment value={'FEMALE'} label="여성" />
    </SegmentGroup>
  );
}

```

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->


Segment에서 value 타입을 잘못 작성했을 때 타입 에러가 뜨도록 구현하고 싶었는데 잘 안되어서 `TODO`로 남겨두었습니다..!