### PR TITLE
Fix : `child.type.name` 체크 에러 해결

### DIFF
--- a/.github/workflows/cd-feature-branch.yml
+++ b/.github/workflows/cd-feature-branch.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'feature/**'
+      - 'hotfix/**'
 
 jobs:
   build:

--- a/src/app/(sub)/join/funnels/step1/components/NumberForm.client.tsx
+++ b/src/app/(sub)/join/funnels/step1/components/NumberForm.client.tsx
@@ -83,12 +83,6 @@ export default function NumberForm({ inputStatus, setInputStatus }: NumberSectio
           <Button disabled={!formState.isValid || timerStatus === 'RUNNING'} type="submit">
             인증번호 전송
           </Button>
-          <Button disabled={!formState.isValid || timerStatus === 'RUNNING'} type="submit">
-            인증번호 전송
-          </Button>
-          <Button disabled={!formState.isValid || timerStatus === 'RUNNING'} type="submit">
-            인증번호 전송
-          </Button>
         </ButtonGroup>
       )}
     </form>

--- a/src/app/(sub)/join/funnels/step1/components/NumberForm.client.tsx
+++ b/src/app/(sub)/join/funnels/step1/components/NumberForm.client.tsx
@@ -83,6 +83,12 @@ export default function NumberForm({ inputStatus, setInputStatus }: NumberSectio
           <Button disabled={!formState.isValid || timerStatus === 'RUNNING'} type="submit">
             인증번호 전송
           </Button>
+          <Button disabled={!formState.isValid || timerStatus === 'RUNNING'} type="submit">
+            인증번호 전송
+          </Button>
+          <Button disabled={!formState.isValid || timerStatus === 'RUNNING'} type="submit">
+            인증번호 전송
+          </Button>
         </ButtonGroup>
       )}
     </form>

--- a/src/components/Button/ButtonGroup.tsx
+++ b/src/components/Button/ButtonGroup.tsx
@@ -62,6 +62,8 @@ export default function ButtonGroup({
       ).name === 'Button'
   ) as ReactElement[];
 
+  console.log(validChildren);
+
   if (validChildren.length === 0) {
     throw new Error('ButtonGroup 컴포넌트는 Button 컴포넌트를 포함해야 합니다.');
   }

--- a/src/components/Button/ButtonGroup.tsx
+++ b/src/components/Button/ButtonGroup.tsx
@@ -52,15 +52,15 @@ export default function ButtonGroup({
   isSpacing = true,
   children,
 }: StrictPropsWithChildren<ButtonGroupProps>) {
-  const validChildren = Children.toArray(children).filter(
-    (child) =>
-      isValidElement(child) &&
-      (
-        child.type as {
-          name: string;
-        }
-      ).name === 'Button'
-  ) as ReactElement[];
+  const validChildren = Children.toArray(children).filter((child) => {
+    console.log(child);
+    console.log(isValidElement(child));
+    // (
+    //   child.type as {
+    //     name: string;
+    //   }
+    // ).name === 'Button'
+  }) as ReactElement[];
 
   console.log(validChildren);
 

--- a/src/components/Button/ButtonGroup.tsx
+++ b/src/components/Button/ButtonGroup.tsx
@@ -52,17 +52,9 @@ export default function ButtonGroup({
   isSpacing = true,
   children,
 }: StrictPropsWithChildren<ButtonGroupProps>) {
-  const validChildren = Children.toArray(children).filter((child) => {
-    console.log(child);
-    console.log(isValidElement(child));
-    // (
-    //   child.type as {
-    //     name: string;
-    //   }
-    // ).name === 'Button'
-  }) as ReactElement[];
-
-  console.log(validChildren);
+  const validChildren = Children.toArray(children).filter((child) =>
+    isValidElement(child)
+  ) as ReactElement[];
 
   if (validChildren.length === 0) {
     throw new Error('ButtonGroup 컴포넌트는 Button 컴포넌트를 포함해야 합니다.');

--- a/src/components/SegmentGroup/SegmentGroup.client.tsx
+++ b/src/components/SegmentGroup/SegmentGroup.client.tsx
@@ -57,14 +57,8 @@ function SegmentGroup<T extends ValueType>({
   children,
   ...props
 }: StrictPropsWithChildren<SegmentGroupProps<T>>) {
-  const validChildren = Children.toArray(children).filter(
-    (child) =>
-      isValidElement(child) &&
-      (
-        child.type as {
-          name: string;
-        }
-      ).name === 'Segment'
+  const validChildren = Children.toArray(children).filter((child) =>
+    isValidElement(child)
   ) as ReactElement[];
 
   if (validChildren.length === 0) {

--- a/src/components/Tabs/Tabs.client.tsx
+++ b/src/components/Tabs/Tabs.client.tsx
@@ -13,23 +13,11 @@ import {
 import type { StrictPropsWithChildren } from '@/types';
 
 export default function Tabs({ children }: StrictPropsWithChildren) {
-  const validListChildren = Children.toArray(children).filter(
-    (child) =>
-      isValidElement(child) &&
-      (
-        child.type as {
-          name: string;
-        }
-      ).name === 'List'
+  const validListChildren = Children.toArray(children).filter((child) =>
+    isValidElement(child)
   ) as ReactElement[];
-  const validPanelChildren = Children.toArray(children).filter(
-    (child) =>
-      isValidElement(child) &&
-      (
-        child.type as {
-          name: string;
-        }
-      ).name === 'Panel'
+  const validPanelChildren = Children.toArray(children).filter((child) =>
+    isValidElement(child)
   ) as ReactElement[];
 
   if (validListChildren.length !== 1) throw new Error('List 컴포넌트는 1개이어야 합니다.');
@@ -65,14 +53,8 @@ interface ListProps {
 }
 
 function List({ isStretch = true, children }: StrictPropsWithChildren<ListProps>) {
-  const validChildren = Children.toArray(children).filter(
-    (child) =>
-      isValidElement(child) &&
-      (
-        child.type as {
-          name: string;
-        }
-      ).name === 'Tab'
+  const validChildren = Children.toArray(children).filter((child) =>
+    isValidElement(child)
   ) as ReactElement[];
 
   if (validChildren.length === 0) {


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 신규 피처

## 💁 무엇이 어떻게 바뀌나요?

1. 아래 사진과 같은 에러가 발생하여, child.type.name 체크하는 로직을 제거하였습니다.
    - development환경과 production환경에서, chlidren의 type > name이 가지고 있는 값이 다르다는 것이 원인이었습니다.
![스크린샷 2023-08-19 오전 9 24 00](https://github.com/gloddy-dev/gloddy-client/assets/62178788/3a4dd2ad-c2a3-4a71-add4-92bb9e05305a)
- 개발환경
![image](https://github.com/gloddy-dev/gloddy-client/assets/62178788/137ea681-9953-4c91-b123-9a1f71944ac5)
- 배포환경
![image](https://github.com/gloddy-dev/gloddy-client/assets/62178788/af8c68a1-d393-415c-ab36-5ad3a8425bd2)

2. 또한, hotfix에서도 feature 배포가 이뤄지도록 `cd.yml`을 수정하였습니다.

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
