### PR TITLE
Fix : Textfield 높이 고정되지 않는 이슈

### DIFF
--- a/src/app/(main)/grouping/[groupId]/apply/components/InputForm.client.tsx
+++ b/src/app/(main)/grouping/[groupId]/apply/components/InputForm.client.tsx
@@ -38,6 +38,7 @@ export default function InputForm() {
         register={register('introduce', { required: true })}
         placeholder="내용을 입력해주세요."
         maxCount={150}
+        elementClassName="h-142"
       />
       <Spacing size={18} />
       <p className="pl-4 text-subtitle-3 text-sign-secondary">모임에 함께 하고 싶은 이유</p>
@@ -48,6 +49,7 @@ export default function InputForm() {
         register={register('reason', { required: true })}
         placeholder="내용을 입력해주세요."
         maxCount={150}
+        elementClassName="h-142"
       />
       <ButtonGroup>
         <Button

--- a/src/app/(main)/grouping/[groupId]/apply/components/InputForm.client.tsx
+++ b/src/app/(main)/grouping/[groupId]/apply/components/InputForm.client.tsx
@@ -38,7 +38,6 @@ export default function InputForm() {
         register={register('introduce', { required: true })}
         placeholder="내용을 입력해주세요."
         maxCount={150}
-        elementClassName="h-142"
       />
       <Spacing size={18} />
       <p className="pl-4 text-subtitle-3 text-sign-secondary">모임에 함께 하고 싶은 이유</p>
@@ -49,7 +48,6 @@ export default function InputForm() {
         register={register('reason', { required: true })}
         placeholder="내용을 입력해주세요."
         maxCount={150}
-        elementClassName="h-142"
       />
       <ButtonGroup>
         <Button

--- a/src/components/TextField/TextField.client.tsx
+++ b/src/components/TextField/TextField.client.tsx
@@ -43,9 +43,10 @@ function TextField<T extends React.ElementType = 'input'>(
   const isError = isLeftError || isRightError;
   const [isFocus, setIsFocus] = useState(false);
   const Element = as || 'input';
+  const id = '' + Math.random();
 
   return (
-    <label ref={ref} htmlFor="textField" className="relative py-8">
+    <label ref={ref} htmlFor={id} className="relative py-8">
       <section
         className={cn(
           'w-full rounded-8 border-1 p-16',
@@ -82,7 +83,7 @@ function TextField<T extends React.ElementType = 'input'>(
             )}
             onFocusCapture={() => !readOnly && setIsFocus(true)}
             onBlurCapture={() => setIsFocus(false)}
-            id="textField"
+            id={id}
             readOnly={readOnly}
             {...register}
             {...props}

--- a/src/components/TextField/TextField.client.tsx
+++ b/src/components/TextField/TextField.client.tsx
@@ -64,11 +64,7 @@ function TextField<T extends React.ElementType = 'input'>(
             <Spacing size={2} />
           </>
         )}
-        <div
-          className={cn('relative flex w-full items-center justify-around', {
-            'h-142': Element === 'textarea',
-          })}
-        >
+        <div className={cn('relative flex w-full items-center justify-around')}>
           {leftIcon}
           <Element
             className={cn(
@@ -79,6 +75,7 @@ function TextField<T extends React.ElementType = 'input'>(
                 'bg-warning-color': isError,
                 'bg-divider placeholder:text-sign-tertiary': readOnly,
                 'indent-8': !!leftIcon,
+                'h-142': Element === 'textarea',
               }
             )}
             onFocusCapture={() => !readOnly && setIsFocus(true)}

--- a/src/components/TextField/TextField.client.tsx
+++ b/src/components/TextField/TextField.client.tsx
@@ -64,7 +64,7 @@ function TextField<T extends React.ElementType = 'input'>(
             <Spacing size={2} />
           </>
         )}
-        <div className={cn('relative flex w-full items-center justify-around')}>
+        <div className="relative flex w-full items-center justify-around">
           {leftIcon}
           <Element
             className={cn(

--- a/src/components/TextField/TextField.client.tsx
+++ b/src/components/TextField/TextField.client.tsx
@@ -5,8 +5,7 @@ import { forwardRef, useState } from 'react';
 
 import type { UseFormRegisterReturn } from 'react-hook-form';
 
-export interface TextFieldProps<T extends React.ElementType = 'input'>
-  extends React.HTMLAttributes<T> {
+export interface TextFieldProps<T extends React.ElementType = 'input'> extends React.HTMLAttributes<T> {
   as?: T;
   register?: UseFormRegisterReturn<string>;
   label?: string;
@@ -20,7 +19,6 @@ export interface TextFieldProps<T extends React.ElementType = 'input'>
   isSpacing?: boolean;
   readOnly?: boolean;
   className?: string;
-  elementClassName?: string;
 }
 
 function TextField<T extends React.ElementType = 'input'>(
@@ -37,7 +35,6 @@ function TextField<T extends React.ElementType = 'input'>(
     isSpacing = true,
     readOnly = false,
     className,
-    elementClassName,
     ...props
   }: TextFieldProps<T> & React.ComponentPropsWithoutRef<T>,
   ref: React.ForwardedRef<HTMLLabelElement>
@@ -56,6 +53,7 @@ function TextField<T extends React.ElementType = 'input'>(
             'border-transparent bg-sub': !isFocus,
             'border-warning bg-warning-color': isError,
             'border-transparent bg-divider': readOnly,
+            'h-142': as === 'textarea',
           },
           className
         )}
@@ -66,7 +64,7 @@ function TextField<T extends React.ElementType = 'input'>(
             <Spacing size={2} />
           </>
         )}
-        <div className="relative flex w-full items-center justify-around">
+        <div className="relative flex h-full w-full items-center justify-around">
           {leftIcon}
           <Element
             className={cn(
@@ -78,9 +76,8 @@ function TextField<T extends React.ElementType = 'input'>(
                 'bg-divider placeholder:text-sign-tertiary': readOnly,
                 'indent-8': !!leftIcon,
                 'h-24': as === 'input',
-                'h-142': as === 'textarea',
-              },
-              elementClassName
+                'h-full': as === 'textarea',
+              }
             )}
             onFocusCapture={() => !readOnly && setIsFocus(true)}
             onBlurCapture={() => setIsFocus(false)}

--- a/src/components/TextField/TextField.client.tsx
+++ b/src/components/TextField/TextField.client.tsx
@@ -5,8 +5,7 @@ import { forwardRef, useState } from 'react';
 
 import type { UseFormRegisterReturn } from 'react-hook-form';
 
-export interface TextFieldProps<T extends React.ElementType = 'input'>
-  extends React.HTMLAttributes<T> {
+export interface TextFieldProps<T extends React.ElementType = 'input'> extends React.HTMLAttributes<T> {
   as?: T;
   register?: UseFormRegisterReturn<string>;
   label?: string;
@@ -20,6 +19,7 @@ export interface TextFieldProps<T extends React.ElementType = 'input'>
   isSpacing?: boolean;
   readOnly?: boolean;
   className?: string;
+  elementClassName?: string;
 }
 
 function TextField<T extends React.ElementType = 'input'>(
@@ -36,6 +36,7 @@ function TextField<T extends React.ElementType = 'input'>(
     isSpacing = true,
     readOnly = false,
     className,
+    elementClassName,
     ...props
   }: TextFieldProps<T> & React.ComponentPropsWithoutRef<T>,
   ref: React.ForwardedRef<HTMLLabelElement>
@@ -75,8 +76,8 @@ function TextField<T extends React.ElementType = 'input'>(
                 'bg-warning-color': isError,
                 'bg-divider placeholder:text-sign-tertiary': readOnly,
                 'indent-8': !!leftIcon,
-                'h-142': Element === 'textarea',
-              }
+              },
+              elementClassName
             )}
             onFocusCapture={() => !readOnly && setIsFocus(true)}
             onBlurCapture={() => setIsFocus(false)}

--- a/src/components/TextField/TextField.client.tsx
+++ b/src/components/TextField/TextField.client.tsx
@@ -5,7 +5,8 @@ import { forwardRef, useState } from 'react';
 
 import type { UseFormRegisterReturn } from 'react-hook-form';
 
-export interface TextFieldProps<T extends React.ElementType = 'input'> extends React.HTMLAttributes<T> {
+export interface TextFieldProps<T extends React.ElementType = 'input'>
+  extends React.HTMLAttributes<T> {
   as?: T;
   register?: UseFormRegisterReturn<string>;
   label?: string;
@@ -69,13 +70,15 @@ function TextField<T extends React.ElementType = 'input'>(
           {leftIcon}
           <Element
             className={cn(
-              'h-24 w-full resize-none text-paragraph-2 outline-none placeholder:text-paragraph-2 placeholder:text-sign-caption',
+              'w-full resize-none text-paragraph-2 outline-none placeholder:text-paragraph-2 placeholder:text-sign-caption',
               {
                 'bg-white': isFocus,
                 'bg-sub': !isFocus,
                 'bg-warning-color': isError,
                 'bg-divider placeholder:text-sign-tertiary': readOnly,
                 'indent-8': !!leftIcon,
+                'h-24': as === 'input',
+                'h-142': as === 'textarea',
               },
               elementClassName
             )}

--- a/src/components/TextField/TextField.client.tsx
+++ b/src/components/TextField/TextField.client.tsx
@@ -5,7 +5,8 @@ import { forwardRef, useState } from 'react';
 
 import type { UseFormRegisterReturn } from 'react-hook-form';
 
-export interface TextFieldProps<T extends React.ElementType = 'input'> extends React.HTMLAttributes<T> {
+export interface TextFieldProps<T extends React.ElementType = 'input'>
+  extends React.HTMLAttributes<T> {
   as?: T;
   register?: UseFormRegisterReturn<string>;
   label?: string;


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 신규 피처

## 💁 무엇이 어떻게 바뀌나요?

1. `h-142`가 바깥 div에 적용되어 너비가 고정되는 이슈가 있었습니다. 이에 따라 input/textarea에 직접적으로 className을 주입하는 elementClassname props를 추가하였습니다.

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
