### PR TITLE
Refactoring : QA - 차단/신고 처리

### DIFF
--- a/src/app/(main)/grouping/[groupId]/articles/[articleId]/components/CommentList.client.tsx
+++ b/src/app/(main)/grouping/[groupId]/articles/[articleId]/components/CommentList.client.tsx
@@ -3,21 +3,22 @@
 import { type Comment, useGetComments, useGetGroupDetail } from '@/apis/groups';
 import { useMoreSheet } from '@/app/(main)/grouping/hooks/useMoreSheet';
 import { CardHeader } from '@/components/Card';
-import { Divider } from '@/components/Divider';
 import { Icon } from '@/components/Icon';
 import { Flex } from '@/components/Layout';
+import { ItemList } from '@/components/List';
 import { Spacing } from '@/components/Spacing';
 import { useNumberParams } from '@/hooks/useNumberParams';
-import { Fragment } from 'react';
+import { useBlockStore } from '@/store/useBlockStore';
 
 export default function CommentList() {
   const { articleId, groupId } = useNumberParams<['articleId', 'groupId']>();
-  const { data: commentsData } = useGetComments(groupId, articleId);
   const { data: groupDetailData } = useGetGroupDetail(groupId);
+  const { data: commentsData } = useGetComments(groupId, articleId);
 
   const { isCaptain } = groupDetailData;
+  const { comments } = commentsData;
 
-  if (commentsData.comments.length === 0)
+  if (comments.length === 0)
     return (
       <Flex direction="column" justify="center" align="center" className="my-80">
         <Icon id="48-cancel" width={48} height={48} />
@@ -27,19 +28,17 @@ export default function CommentList() {
     );
 
   return (
-    <div>
-      {commentsData.comments.map((comment) => (
-        <Fragment key={comment.commentId}>
-          <CommentItem
-            comment={comment}
-            groupId={groupId}
-            articleId={articleId}
-            isCaptain={isCaptain}
-          />
-          <Divider thickness="thin" />
-        </Fragment>
-      ))}
-    </div>
+    <ItemList
+      data={comments}
+      renderItem={(comment) => (
+        <CommentItem
+          comment={comment}
+          groupId={groupId}
+          articleId={articleId}
+          isCaptain={isCaptain}
+        />
+      )}
+    />
   );
 }
 interface CommentItemProps {
@@ -50,7 +49,10 @@ interface CommentItemProps {
 }
 
 function CommentItem({ comment, articleId, groupId, isCaptain }: CommentItemProps) {
+  const { blockCommentIds } = useBlockStore();
   const { content, commentId, isWriter } = comment;
+
+  const isBlocked = blockCommentIds.includes(commentId);
 
   const { handleMoreClick } = useMoreSheet({
     type: 'comment',
@@ -63,9 +65,11 @@ function CommentItem({ comment, articleId, groupId, isCaptain }: CommentItemProp
 
   return (
     <Flex direction="column" className="m-20 mb-20 px-4">
-      <CardHeader onMoreClick={handleMoreClick} showMoreIcon {...comment} />
+      <CardHeader onMoreClick={handleMoreClick} showMoreIcon={!isBlocked} {...comment} />
       <Spacing size={8} />
-      <div className="break-words text-paragraph-2 text-sign-primary">{content}</div>
+      <div className="break-words text-paragraph-2 text-sign-primary">
+        {isBlocked ? '차단된 댓글입니다.' : content}
+      </div>
     </Flex>
   );
 }

--- a/src/app/(main)/grouping/[groupId]/articles/[articleId]/page.tsx
+++ b/src/app/(main)/grouping/[groupId]/articles/[articleId]/page.tsx
@@ -23,7 +23,10 @@ export default function ArticlePage({ params }: ArticleDetailPageProps) {
   return (
     <>
       <ArticleHeader />
-      <QueryAsyncBoundary rejectedFallback={RejectedFallback} pendingFallback={<Loading />}>
+      <QueryAsyncBoundary
+        rejectedFallback={RejectedFallback}
+        pendingFallback={<Loading className="h-[calc(100dvh-250px)]" />}
+      >
         <PageAnimation>
           <HydrationProvider
             queryFn={() => getArticle(groupId, articleId)}

--- a/src/app/(main)/grouping/[groupId]/components/GroupDetailHeader.client.tsx
+++ b/src/app/(main)/grouping/[groupId]/components/GroupDetailHeader.client.tsx
@@ -10,6 +10,7 @@ import { Icon } from '@/components/Icon';
 import MoreBottomSheet from '@/components/Modal/MoreBottomSheet.client';
 import { useModal } from '@/hooks/useModal';
 import { useNumberParams } from '@/hooks/useNumberParams';
+import { useBlockStore } from '@/store/useBlockStore';
 import { useRouter } from 'next/navigation';
 import { Suspense } from 'react';
 
@@ -63,6 +64,8 @@ function ManageButtonAction({ groupId }: ActionProps) {
 }
 
 function MoreButtonAction({ groupId }: ActionProps) {
+  const router = useRouter();
+  const { setBlockId } = useBlockStore();
   const { open: openBottomSheet, close: closeBottomSheet } = useModal();
   const { open: openItemModal, exit: exitItemModal } = useModal();
   const { open: openDoneModal, exit: exitDoneModal } = useModal();
@@ -76,15 +79,33 @@ function MoreButtonAction({ groupId }: ActionProps) {
   };
 
   const handleReportClick = () => {
+    setBlockId(groupId, 'group');
     exitItemModal();
     closeBottomSheet();
-    openDoneModal(() => <ReportDoneModal onOkClick={exitDoneModal} />);
+    openDoneModal(() => (
+      <ReportDoneModal
+        onOkClick={() => {
+          exitDoneModal();
+          router.replace('/grouping');
+          router.back(); // tab에 의해 스택이 두개가 쌓여있어 한번 더 뒤로가기
+        }}
+      />
+    ));
   };
 
   const handleBlockClick = () => {
+    setBlockId(groupId, 'group');
     exitItemModal();
     closeBottomSheet();
-    openDoneModal(() => <BlockDoneModal onOkClick={exitDoneModal} />);
+    openDoneModal(() => (
+      <BlockDoneModal
+        onOkClick={() => {
+          exitDoneModal();
+          router.replace('/grouping');
+          router.back(); // tab에 의해 스택이 두개가 쌓여있어 한번 더 뒤로가기
+        }}
+      />
+    ));
   };
 
   const handleMoreClick = () => {

--- a/src/app/(main)/grouping/[groupId]/components/articles/ArticleSection.client.tsx
+++ b/src/app/(main)/grouping/[groupId]/components/articles/ArticleSection.client.tsx
@@ -4,21 +4,27 @@ import { useGetArticles, useGetGroupDetail } from '@/apis/groups/queries';
 import ArticleItem from '@/app/(main)/grouping/components/ArticleItem.client';
 import { ItemList } from '@/components/List';
 import { useNumberParams } from '@/hooks/useNumberParams';
+import { useBlockStore } from '@/store/useBlockStore';
 
 export default function ArticleSection() {
+  const { blockArticleIds } = useBlockStore();
   const { groupId } = useNumberParams<['groupId']>();
-
   const { data: articlesData } = useGetArticles(groupId);
   const { data: groupDetailData } = useGetGroupDetail(groupId);
+
   const { isCaptain } = groupDetailData;
 
   return (
     <section>
       <ItemList
         data={articlesData}
-        renderItem={(article) => (
-          <ArticleItem article={article} isCaptain={isCaptain} groupId={groupId} />
-        )}
+        renderItem={(article) => {
+          return (
+            !blockArticleIds.includes(article.articleId) && (
+              <ArticleItem article={article} isCaptain={isCaptain} groupId={groupId} />
+            )
+          );
+        }}
       />
     </section>
   );

--- a/src/app/(main)/grouping/[groupId]/components/articles/NoticeSection.client.tsx
+++ b/src/app/(main)/grouping/[groupId]/components/articles/NoticeSection.client.tsx
@@ -7,8 +7,10 @@ import { Flex } from '@/components/Layout';
 import { ItemList } from '@/components/List';
 import { Spacing } from '@/components/Spacing';
 import { useNumberParams } from '@/hooks/useNumberParams';
+import { useBlockStore } from '@/store/useBlockStore';
 
 export default function NoticeSection() {
+  const { blockNoticeIds } = useBlockStore();
   const { groupId } = useNumberParams<['groupId']>();
 
   const { data: groupDetailData } = useGetGroupDetail(groupId);
@@ -16,20 +18,24 @@ export default function NoticeSection() {
 
   const { data: noticesData } = useGetNotices(groupId);
 
+  const notices = noticesData.filter((notice) => !blockNoticeIds.includes(notice.noticeId));
+
   return (
     <section className="p-20 pb-8">
       <div className="rounded-8 bg-card-ui p-16 text-subtitle-3 text-sign-secondary">
         <p className="pl-4">공지사항</p>
         <Spacing size={6} />
-        {noticesData.length === 0 ? (
-          <EmptyNotice />
-        ) : (
+        {notices.length ? (
           <ItemList
-            data={noticesData}
-            renderItem={(notice) => (
-              <NoticeItem notice={notice} groupId={groupId} isCaptain={isCaptain} />
-            )}
+            data={notices}
+            renderItem={(notice) =>
+              !blockNoticeIds.includes(notice.noticeId) && (
+                <NoticeItem notice={notice} groupId={groupId} isCaptain={isCaptain} />
+              )
+            }
           />
+        ) : (
+          <EmptyNotice />
         )}
       </div>
     </section>

--- a/src/app/(main)/grouping/components/GroupingCardList.client.tsx
+++ b/src/app/(main)/grouping/components/GroupingCardList.client.tsx
@@ -4,6 +4,7 @@ import { GroupingCard } from '@/components/Card';
 import { ItemList } from '@/components/List';
 import { Loading } from '@/components/Loading';
 import useIntersect from '@/hooks/useIntersect';
+import { Delay } from '@suspensive/react';
 import { useCallback } from 'react';
 import PullToRefresh from 'react-simple-pull-to-refresh';
 

--- a/src/app/(main)/grouping/components/GroupingCardList.client.tsx
+++ b/src/app/(main)/grouping/components/GroupingCardList.client.tsx
@@ -4,11 +4,12 @@ import { GroupingCard } from '@/components/Card';
 import { ItemList } from '@/components/List';
 import { Loading } from '@/components/Loading';
 import useIntersect from '@/hooks/useIntersect';
-import { Delay } from '@suspensive/react';
+import { useBlockStore } from '@/store/useBlockStore';
 import { useCallback } from 'react';
 import PullToRefresh from 'react-simple-pull-to-refresh';
 
 export default function GroupingCardList() {
+  const { blockGroupIds } = useBlockStore();
   const { data, fetchNextPage, hasNextPage, remove, isLoading, refetch } = useGetGroups();
 
   const onIntersect = useCallback(async () => {
@@ -32,7 +33,12 @@ export default function GroupingCardList() {
         refreshingContent={<Loading className="h-60" />}
         resistance={2}
       >
-        <ItemList data={data} renderItem={(grouping) => <GroupingCard groupingData={grouping} />} />
+        <ItemList
+          data={data}
+          renderItem={(grouping) =>
+            !blockGroupIds.includes(grouping.groupId) && <GroupingCard groupingData={grouping} />
+          }
+        />
       </PullToRefresh>
       <div ref={target} />
     </>

--- a/src/app/(main)/grouping/hooks/useMoreSheet.tsx
+++ b/src/app/(main)/grouping/hooks/useMoreSheet.tsx
@@ -5,6 +5,8 @@ import WarningModal from '../components/WarningModal.client';
 import { useDeleteArticle, useDeleteComment } from '@/apis/groups';
 import MoreBottomSheet from '@/components/Modal/MoreBottomSheet.client';
 import { useModal } from '@/hooks/useModal';
+import { useBlockStore } from '@/store/useBlockStore';
+import { useRouter } from 'next/navigation';
 
 type CommentId<T> = T extends 'comment' ? { commentId: number } : { commentId?: never };
 
@@ -24,6 +26,8 @@ export function useMoreSheet<T extends 'article' | 'comment' | 'notice'>({
   articleId,
   commentId,
 }: MoreSheetProps<T> & CommentId<T>) {
+  const router = useRouter();
+  const { setBlockId } = useBlockStore();
   const { open: openBottomSheet, close: closeBottomSheet } = useModal();
   const { open: openItemModal, exit: exitItemModal } = useModal();
   const { open: openDoneModal, exit: exitDoneModal } = useModal();
@@ -63,15 +67,39 @@ export function useMoreSheet<T extends 'article' | 'comment' | 'notice'>({
   };
 
   const handleReportClick = () => {
+    const blockId = type === 'comment' ? commentId! : articleId;
+
     exitItemModal();
     closeBottomSheet();
-    openDoneModal(() => <ReportDoneModal onOkClick={exitDoneModal} />);
+    openDoneModal(() => (
+      <ReportDoneModal
+        onOkClick={() => {
+          setBlockId(blockId, type);
+          exitDoneModal();
+          if (type !== 'comment') {
+            router.replace(`/grouping/${groupId}?tab=articles`);
+          }
+        }}
+      />
+    ));
   };
 
   const handleBlockClick = () => {
+    const blockId = type === 'comment' ? commentId! : articleId;
+
     exitItemModal();
     closeBottomSheet();
-    openDoneModal(() => <BlockDoneModal onOkClick={exitDoneModal} />);
+    openDoneModal(() => (
+      <BlockDoneModal
+        onOkClick={() => {
+          setBlockId(blockId, type);
+          exitDoneModal();
+          if (type !== 'comment') {
+            router.replace(`/grouping/${groupId}?tab=articles`);
+          }
+        }}
+      />
+    ));
   };
 
   const handleMoreClick = () => {
@@ -119,18 +147,6 @@ export function useMoreSheet<T extends 'article' | 'comment' | 'notice'>({
       </MoreBottomSheet>
     ));
   };
-
-  function DeleteItem() {
-    const { open, close } = useModal();
-
-    open(() => (
-      <WarningModal
-        content={`해당 ${content}을 삭제하시겠습니까?`}
-        onCancelClick={close}
-        onOkClick={handleDeleteClick}
-      />
-    ));
-  }
 
   return {
     handleMoreClick,

--- a/src/app/(main)/meeting/participate/components/RejectModal.tsx
+++ b/src/app/(main)/meeting/participate/components/RejectModal.tsx
@@ -23,7 +23,7 @@ export default function RejectModal({ applyId }: RejectModalProps) {
       </p>
       <Spacing size={20} />
       <div className="py-12">
-        <Button onClick={() => router.back()}>다른 모임 지원하러 가기</Button>
+        <Button onClick={() => router.push('/grouping')}>다른 모임 지원하러 가기</Button>
       </div>
     </Modal>
   );

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -31,7 +31,7 @@ export default function Avatar({
 }: PropsWithChildren<AvatarProps>) {
   return (
     <span
-      className={cn('relative flex shrink-0 flex-col items-center gap-1 overflow-hidden', {
+      className={cn('relative flex shrink-0 flex-col items-center gap-1', {
         'w-40': size === 'small',
         'w-56': size === 'medium',
         'w-96': size === 'large',

--- a/src/components/Button/ButtonGroup.tsx
+++ b/src/components/Button/ButtonGroup.tsx
@@ -79,14 +79,15 @@ export default function ButtonGroup({
   return (
     <>
       {position === 'bottom' && isSpacing && <Spacing size={buttonHeight + 28} />}
-      <BottomFixedDiv
+      <div
         className={cn({
-          'z-50 bg-white p-20 pt-7': position === 'bottom',
+          'fixed inset-x-0 bottom-0 z-50 mx-auto max-w-450 bg-white p-20 pt-7':
+            position === 'bottom',
           'border-t-1 border-divider': hasDivider,
         })}
       >
         {renderElements(validChildren, props)}
-      </BottomFixedDiv>
+      </div>
     </>
   );
 }

--- a/src/components/Card/GroupingCard.client.tsx
+++ b/src/components/Card/GroupingCard.client.tsx
@@ -56,11 +56,12 @@ export default function GroupingCard({
   return (
     <Flex className="bg-white px-20 py-16" direction="column">
       <Flex
-        onClick={() =>
+        onClick={
           onClick ||
-          router.push(`/grouping/${groupId}`, {
-            scroll: false,
-          })
+          (() =>
+            router.push(`/grouping/${groupId}`, {
+              scroll: false,
+            }))
         }
         align="center"
       >
@@ -112,7 +113,7 @@ function MemberCountBadge({ maxMemeberCount, memberCount }: MemberCountBadgeProp
   return (
     <Flex
       align="center"
-      className={cn('absolute bottom-0 left-0 h-22 w-45 rounded-4 p-4', {
+      className={cn('absolute bottom-0 left-0 h-22 rounded-4 p-4', {
         'bg-brand-color': leftUser >= 2,
         'bg-warning-color': leftUser === 1,
         'bg-sub': leftUser === 0,

--- a/src/components/Card/GroupingCard.client.tsx
+++ b/src/components/Card/GroupingCard.client.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { IconButton } from '../Button';
 import { Icon } from '../Icon';
 import { useDeleteScrapMeeting } from '@/apis/groups';
 import { Flex } from '@/components/Layout';
@@ -65,7 +64,7 @@ export default function GroupingCard({
         }
         align="center"
       >
-        <section className="relative h-96 w-96">
+        <section className="relative h-96 w-96 shrink-0">
           {imageUrl ? (
             <Image fill src={imageUrl} alt="group" className="rounded-8 object-cover" />
           ) : (
@@ -76,23 +75,25 @@ export default function GroupingCard({
 
         <Spacing size={12} direction="horizontal" />
 
-        <section className="relative grow">
-          <p className="w-250 truncate text-subtitle-1">{title}</p>
-          <p className="w-250 truncate text-paragraph-2 text-sign-secondary">{content}</p>
+        <section className="relative grow overflow-hidden">
+          <Flex align="center">
+            <p className="grow truncate text-subtitle-1">{title}</p>
+            {isScrapped && <ScrapBadge groupId={groupId} />}
+            {status && <StatusBadge status={status} />}
+          </Flex>
+          <p className="truncate text-paragraph-2 text-sign-secondary">{content}</p>
           <Spacing size={8} />
-          <div className="flex text-caption text-sign-tertiary">
+          <Flex align="center" className="text-caption text-sign-tertiary">
             <Icon id="16-location" width={16} height={16} />
             <Spacing size={4} direction="horizontal" />
-            {placeAddress}
-          </div>
+            <p className="truncate">{placeAddress}</p>
+          </Flex>
           <Spacing size={4} />
-          <div className="flex text-caption text-sign-tertiary">
+          <Flex align="center" className="text-caption text-sign-tertiary">
             <Icon id="16-date_range" width={16} height={16} />
             <Spacing size={4} direction="horizontal" />
-            {formatMeetingDate(meetDate, startTime)}
-          </div>
-          {isScrapped && <ScrapBadge groupId={groupId} />}
-          {status && <StatusBadge status={status} />}
+            <p className="truncate">{formatMeetingDate(meetDate, startTime)}</p>
+          </Flex>
         </section>
       </Flex>
       {children}
@@ -146,14 +147,11 @@ interface StatusBadgeProps {
 function StatusBadge({ status }: StatusBadgeProps) {
   return (
     <Flex
-      className={cn(
-        'absolute right-0 top-2 inline h-22 rounded-4 border-1 px-4 py-2 text-caption',
-        {
-          'border-warning bg-warning-color text-warning': warningBadge.includes(status),
-          'border-sign-tertiary bg-sub text-sign-tertiary': grayBadge.includes(status),
-          'border-primary bg-brand-color text-primary': blueBadge.includes(status),
-        }
-      )}
+      className={cn('h-22 shrink-0 rounded-4 border-1 px-4 py-2 text-caption', {
+        'border-warning bg-warning-color text-warning': warningBadge.includes(status),
+        'border-sign-tertiary bg-sub text-sign-tertiary': grayBadge.includes(status),
+        'border-primary bg-brand-color text-primary': blueBadge.includes(status),
+      })}
     >
       {status}
     </Flex>
@@ -167,15 +165,13 @@ interface ScrapBadgeProps {
 function ScrapBadge({ groupId }: ScrapBadgeProps) {
   const { mutate: mutateDeleteScrap } = useDeleteScrapMeeting(groupId);
   return (
-    <IconButton
-      size="medium"
-      className="absolute right-0 top-0"
+    <Icon
+      id="24-scrap_fixed"
       onClick={(e) => {
         e.stopPropagation();
         mutateDeleteScrap({ params: { groupId } });
       }}
-    >
-      <Icon id="24-scrap_fixed" />
-    </IconButton>
+      className="mx-12"
+    />
   );
 }

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,12 +1,22 @@
+import cn from '@/utils/cn';
+
 import type { SVGProps } from 'react';
 
 interface IconProps extends SVGProps<SVGSVGElement> {
   id: string;
+  className?: string;
 }
 
-export default function Icon({ id, width = 24, height = 24, fill = 'none', ...rest }: IconProps) {
+export default function Icon({
+  id,
+  width = 24,
+  height = 24,
+  fill = 'none',
+  className,
+  ...rest
+}: IconProps) {
   return (
-    <svg width={width} height={height} fill={fill} {...rest}>
+    <svg width={width} height={height} fill={fill} className={cn('shrink-0', className)} {...rest}>
       <use href={`/sprite/sprite.svg#${id}`} />
     </svg>
   );

--- a/src/components/List/ItemList.tsx
+++ b/src/components/List/ItemList.tsx
@@ -4,7 +4,7 @@ import { ComponentProps, Fragment } from 'react';
 
 interface ItemListProps<T> extends Omit<ComponentProps<typeof Flex>, 'children'> {
   data: T[];
-  renderItem: (data: T) => JSX.Element;
+  renderItem: (data: T) => JSX.Element | boolean | null | undefined;
   direction?: 'row' | 'column';
   className?: string;
   hasDivider?: boolean;
@@ -24,7 +24,7 @@ export default function ItemList<T>({
         return (
           <Fragment key={index}>
             {renderItem(item)}
-            {hasDivider && index !== data.length - 1 && <Divider />}
+            {renderItem(item) && hasDivider && index !== data.length - 1 && <Divider />}
           </Fragment>
         );
       })}

--- a/src/store/useBlockStore.ts
+++ b/src/store/useBlockStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+type BlockState = {
+  blockGroupIds: number[];
+  blockArticleIds: number[];
+  blockCommentIds: number[];
+  blockNoticeIds: number[];
+  setBlockId: (id: number, type: 'group' | 'article' | 'comment' | 'notice') => void;
+};
+
+export const useBlockStore = create(
+  persist<BlockState>(
+    (set) => ({
+      blockArticleIds: [],
+      blockCommentIds: [],
+      blockGroupIds: [],
+      blockNoticeIds: [],
+      setBlockId: (id: number, type: 'group' | 'article' | 'comment' | 'notice') => {
+        set((state) => {
+          const capitalizedState = ('block' +
+            (type.charAt(0).toUpperCase() + type.slice(1)) +
+            'Ids') as keyof Omit<BlockState, 'setBlockId'>;
+
+          if (state[capitalizedState].includes(id)) return state;
+
+          return {
+            ...state,
+            [capitalizedState]: [...state[capitalizedState], id],
+          };
+        });
+      },
+    }),
+    {
+      name: 'blockIds',
+      storage: createJSONStorage(() => localStorage), // (optional) by default, 'localStorage' is used
+    }
+  )
+);


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 신규 피처

## 💁 무엇이 어떻게 바뀌나요?

1. 차단/신고 시 가려지거나 화면에 보이지 않도록 처리했습니다.
2. 추가로 공통 컴포넌트를 수정했습니다.
- ButtonGroup의 position이 contents일 때 아래에 고정되면 안되기 때문에 BottomFixedDiv 컴포넌트 사용하지 않도록 변경
- GroupingCard 수정
- Avatar 불필요한 스타일 제거
- ItemList의 renderItem 타입 변경
## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->


가끔 이런 에러가 나타나고 있습니다.

```
VM1081 queries.ts:3 Uncaught (in promise) ReferenceError: Cannot access 'useGetNicknameDuplicate' before initialization
    at Module.useGetNicknameDuplicate (webpack-internal:///(app-pages-browser)/./src/apis/auth/queries.ts:3:62)
    at Module.useGetNicknameDuplicate (webpack-internal:///(app-pages-browser)/./src/apis/auth/index.ts:15:127)
    at Object.registerExportsForReactRefresh (webpack-internal:///(app-pages-browser)/./.yarn/__virtual__/next-virtual-8538f1fb30/0/cache/next-npm-13.4.19-bc82e788ec-f4873dab88.zip/node_modules/next/dist/compiled/@next/react-refresh-utils/dist/internal/helpers.js:52:40)
    at eval (webpack-internal:///(app-pages-browser)/./src/apis/auth/index.ts:52:35)
    at eval (webpack-internal:///(app-pages-browser)/./src/apis/auth/index.ts:95:7)
    at (app-pages-browser)/./src/apis/auth/index.ts (http://localhost:3000/_next/static/chunks/app/(main)/grouping/page.js:237:1)
    at options.factory (webpack.js?v=1694365282278:731:31)
    at __webpack_require__ (webpack.js?v=1694365282278:37:33)
    at fn (webpack.js?v=1694365282278:386:21)
    at eval (webpack-internal:///(app-pages-browser)/./src/apis/auth/queries.ts:6:59)
    at (app-pages-browser)/./src/apis/auth/queries.ts (http://localhost:3000/_next/static/chunks/app/(main)/grouping/page.js:270:1)
    at options.factory (webpack.js?v=1694365282278:731:31)
    at __webpack_require__ (webpack.js?v=1694365282278:37:33)
    at Function.fn (webpack.js?v=1694365282278:386:21)
```