### PR TITLE
Fix : 무한 요청 이슈 fix

### DIFF
--- a/src/apis/groups/apis.ts
+++ b/src/apis/groups/apis.ts
@@ -38,7 +38,7 @@ export const postCreateGroup = (CreateGroupData: CreateGroupRequest) => {
 };
 
 export const getArticles = (groupId: number, page: number) => {
-  return privateApi.get<ArticlesResponse>(`/groups/${groupId}/articles?size=40&page=${page}`);
+  return privateApi.get<ArticlesResponse>(`/groups/${groupId}/articles?size=5&page=${page}`);
 };
 
 export const getArticle = (groupId: number, articleId: number) => {

--- a/src/apis/groups/keys.ts
+++ b/src/apis/groups/keys.ts
@@ -5,7 +5,7 @@ export const Keys = Object.freeze({
   getArticle: (groupId: number, articleId: number) => ['getArticle', groupId, articleId],
   getComments: (groupId: number, articleId: number) => ['getComments', groupId, articleId],
   getGroupMembers: (groupId: number) => ['getGroupMembers', groupId],
-  getNotice: (groupId: number) => ['getNotice', groupId],
+  getNotices: (groupId: number) => ['getNotices', groupId],
   getApplies: (groupId: number) => ['getApplies', groupId],
   getEstimate: (groupId: number) => ['getEstimate', groupId],
 });

--- a/src/apis/groups/mutations.tsx
+++ b/src/apis/groups/mutations.tsx
@@ -39,7 +39,7 @@ export const usePostArticle = (groupId: number) => {
   return useMutation(postArticle, {
     onSuccess: (data) => {
       queryClient.invalidateQueries(GroupsKeys.getArticles(groupId));
-      queryClient.invalidateQueries(GroupsKeys.getNotice(groupId));
+      queryClient.invalidateQueries(GroupsKeys.getNotices(groupId));
       router.replace(`/grouping/${groupId}/articles/${data.articleId}`);
     },
   });
@@ -52,7 +52,7 @@ export const useDeleteArticle = (groupId: number) => {
   return useMutation(deleteArticle, {
     onSuccess: () => {
       queryClient.invalidateQueries(GroupsKeys.getArticles(groupId));
-      queryClient.invalidateQueries(GroupsKeys.getNotice(groupId));
+      queryClient.invalidateQueries(GroupsKeys.getNotices(groupId));
       router.replace(`/grouping/${groupId}?tab=articles`);
     },
   });

--- a/src/apis/groups/queries.ts
+++ b/src/apis/groups/queries.ts
@@ -71,7 +71,7 @@ export const useGetGroupMembers = (groupId: number) => {
 };
 
 export const useGetNotices = (groupId: number) => {
-  return useSuspenseQuery(Keys.getNotice(groupId), () => getNotices(groupId));
+  return useSuspenseQuery(Keys.getNotices(groupId), () => getNotices(groupId));
 };
 
 export const useGetApplies = (groupId: number) => {

--- a/src/app/[lng]/(main)/grouping/[groupId]/articles/[articleId]/components/CommentList.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/articles/[articleId]/components/CommentList.client.tsx
@@ -12,22 +12,12 @@ import { useNumberParams } from '@/hooks/useNumberParams';
 import { useBlockStore } from '@/store/useBlockStore';
 
 export default function CommentList() {
-  const { t } = useTranslation('groupDetail');
   const { articleId, groupId } = useNumberParams<['articleId', 'groupId']>();
   const { data: groupDetailData } = useGetGroupDetail(groupId);
   const { data: commentsData } = useGetComments(groupId, articleId);
 
   const { isCaptain } = groupDetailData;
   const { comments } = commentsData;
-
-  if (comments.length === 0)
-    return (
-      <Flex direction="column" justify="center" align="center" className="my-80">
-        <Icon id="48-cancel" width={48} height={48} />
-        <Spacing size={8} />
-        <p className="text-sign-tertiary">{t('comment.firstComment')}</p>
-      </Flex>
-    );
 
   return (
     <ItemList
@@ -40,6 +30,7 @@ export default function CommentList() {
           isCaptain={isCaptain}
         />
       )}
+      renderEmpty={() => <EmptyComment />}
     />
   );
 }
@@ -73,6 +64,18 @@ function CommentItem({ comment, articleId, groupId, isCaptain }: CommentItemProp
       <div className="break-words text-paragraph-2 text-sign-primary">
         {isBlocked ? t('comment.blockComment') : content}
       </div>
+    </Flex>
+  );
+}
+
+function EmptyComment() {
+  const { t } = useTranslation('groupDetail');
+
+  return (
+    <Flex direction="column" justify="center" align="center" className="my-80">
+      <Icon id="48-cancel" width={48} height={48} />
+      <Spacing size={8} />
+      <p className="text-sign-tertiary">{t('comment.firstComment')}</p>
     </Flex>
   );
 }

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/GroupDetail.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/GroupDetail.client.tsx
@@ -11,6 +11,7 @@ import { Spacing } from '@/components/Spacing';
 import { Tabs } from '@/components/Tabs';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { Suspense } from 'react';
 
 interface GroupDetailProps {
   groupId: number;
@@ -33,23 +34,27 @@ export default function GroupDetailPage({ groupId }: GroupDetailProps) {
           <Tabs.Tab value="articles" text={t('board.tab')} disabled={!myGroup} />
         </Tabs.List>
         <Tabs.Panel value="detail">
-          <div className="px-20">
-            <Spacing size={20} />
-            <MemberSection />
-            <Spacing size={36} />
-            <TimeSection />
-            <Spacing size={28} />
-            <LocationSection />
-          </div>
+          <Suspense>
+            <div className="px-20">
+              <Spacing size={20} />
+              <MemberSection />
+              <Spacing size={36} />
+              <TimeSection />
+              <Spacing size={28} />
+              <LocationSection />
+            </div>
+          </Suspense>
         </Tabs.Panel>
         <Tabs.Panel value="articles">
-          <NoticeSection />
-          <ArticleSection />
-          <div className="bottom-fixed flex justify-end">
-            <Link href={`/grouping/${groupId}/write`}>
-              <FloatAddButton />
-            </Link>
-          </div>
+          <Suspense>
+            <NoticeSection />
+            <ArticleSection />
+            <div className="bottom-fixed flex justify-end">
+              <Link href={`/grouping/${groupId}/write`}>
+                <FloatAddButton />
+              </Link>
+            </div>
+          </Suspense>
         </Tabs.Panel>
       </Tabs>
 

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/GroupDetail.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/GroupDetail.client.tsx
@@ -1,21 +1,17 @@
 'use client';
 
-import { ArticleSection, NoticeSection } from './articles';
+import ArticlesContent from './articles/ArticlesContent.client';
 import DetailContent from './detail/DetailContent.client';
 import TopSection from './TopSection.client';
 import { useGetGroupDetail } from '@/apis/groups';
 import { useTranslation } from '@/app/i18n/client';
-import { FloatAddButton } from '@/components/Button';
 import { Divider } from '@/components/Divider';
 import { Spacing } from '@/components/Spacing';
 import { Tabs } from '@/components/Tabs';
 import { useNumberParams } from '@/hooks/useNumberParams';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import { Suspense } from 'react';
 
 export default function GroupDetailPage() {
-  const pathname = usePathname();
   const { t } = useTranslation('groupDetail');
   const { groupId } = useNumberParams<['groupId']>();
   const { data: groupDetailData } = useGetGroupDetail(groupId);
@@ -31,21 +27,16 @@ export default function GroupDetailPage() {
           <Tabs.Tab value="articles" text={t('board.tab')} disabled={!myGroup} />
         </Tabs.List>
         <Tabs.Panel value="detail">
-          <DetailContent />
+          <Suspense>
+            <DetailContent />
+          </Suspense>
         </Tabs.Panel>
         <Tabs.Panel value="articles">
           <Suspense>
-            <NoticeSection />
-            <ArticleSection />
-            <div className="bottom-fixed flex justify-end">
-              <Link href={`${pathname}/write`}>
-                <FloatAddButton />
-              </Link>
-            </div>
+            <ArticlesContent />
           </Suspense>
         </Tabs.Panel>
       </Tabs>
-
       <Spacing size={60} />
     </>
   );

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/GroupDetail.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/GroupDetail.client.tsx
@@ -1,28 +1,25 @@
 'use client';
 
 import { ArticleSection, NoticeSection } from './articles';
-import { LocationSection, MemberSection, TimeSection } from './detail';
+import DetailContent from './detail/DetailContent.client';
 import TopSection from './TopSection.client';
 import { useGetGroupDetail } from '@/apis/groups';
 import { useTranslation } from '@/app/i18n/client';
-import { Button, ButtonGroup, FloatAddButton } from '@/components/Button';
+import { FloatAddButton } from '@/components/Button';
 import { Divider } from '@/components/Divider';
 import { Spacing } from '@/components/Spacing';
 import { Tabs } from '@/components/Tabs';
+import { useNumberParams } from '@/hooks/useNumberParams';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { Suspense } from 'react';
 
-interface GroupDetailProps {
-  groupId: number;
-}
-
-export default function GroupDetailPage({ groupId }: GroupDetailProps) {
+export default function GroupDetailPage() {
+  const pathname = usePathname();
   const { t } = useTranslation('groupDetail');
+  const { groupId } = useNumberParams<['groupId']>();
   const { data: groupDetailData } = useGetGroupDetail(groupId);
-  const router = useRouter();
-
-  const { myGroup, isApplyWaited } = groupDetailData;
+  const { myGroup } = groupDetailData;
 
   return (
     <>
@@ -34,23 +31,14 @@ export default function GroupDetailPage({ groupId }: GroupDetailProps) {
           <Tabs.Tab value="articles" text={t('board.tab')} disabled={!myGroup} />
         </Tabs.List>
         <Tabs.Panel value="detail">
-          <Suspense>
-            <div className="px-20">
-              <Spacing size={20} />
-              <MemberSection />
-              <Spacing size={36} />
-              <TimeSection />
-              <Spacing size={28} />
-              <LocationSection />
-            </div>
-          </Suspense>
+          <DetailContent />
         </Tabs.Panel>
         <Tabs.Panel value="articles">
           <Suspense>
             <NoticeSection />
             <ArticleSection />
             <div className="bottom-fixed flex justify-end">
-              <Link href={`/grouping/${groupId}/write`}>
+              <Link href={`${pathname}/write`}>
                 <FloatAddButton />
               </Link>
             </div>
@@ -59,16 +47,6 @@ export default function GroupDetailPage({ groupId }: GroupDetailProps) {
       </Tabs>
 
       <Spacing size={60} />
-      {!myGroup && (
-        <ButtonGroup>
-          <Button
-            onClick={() => router.push(`/grouping/${groupId}/apply`)}
-            disabled={isApplyWaited}
-          >
-            {t(isApplyWaited ? 'details.wait' : 'details.join')}
-          </Button>
-        </ButtonGroup>
-      )}
     </>
   );
 }

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/articles/ArticleSection.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/articles/ArticleSection.client.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import { useGetArticles, useGetGroupDetail } from '@/apis/groups/queries';
+import { GroupDetailResponse } from '@/apis/groups';
+import { useGetArticles } from '@/apis/groups/queries';
 import ArticleItem from '@/app/[lng]/(main)/grouping/components/ArticleItem.client';
 import { ItemList } from '@/components/List';
 import { useNumberParams } from '@/hooks/useNumberParams';
 import { useBlockStore } from '@/store/useBlockStore';
 
-export default function ArticleSection() {
+interface ArticlesContentProps extends GroupDetailResponse {}
+
+export default function ArticleSection({ isCaptain }: ArticlesContentProps) {
   const { blockArticleIds } = useBlockStore();
   const { groupId } = useNumberParams<['groupId']>();
   const { data: articlesData } = useGetArticles(groupId);
-  const { data: groupDetailData } = useGetGroupDetail(groupId);
-
-  const { isCaptain } = groupDetailData;
 
   return (
     <section>

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/articles/ArticlesContent.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/articles/ArticlesContent.client.tsx
@@ -1,0 +1,26 @@
+import ArticleSection from './ArticleSection.client';
+import NoticeSection from './NoticeSection.client';
+import { useGetGroupDetail } from '@/apis/groups';
+import { FloatAddButton } from '@/components/Button';
+import { useNumberParams } from '@/hooks/useNumberParams';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export default function ArticlesContent() {
+  const pathname = usePathname();
+  const { groupId } = useNumberParams<['groupId']>();
+
+  const { data: groupDetailData } = useGetGroupDetail(groupId);
+
+  return (
+    <>
+      <NoticeSection {...groupDetailData} />
+      <ArticleSection {...groupDetailData} />
+      <div className="bottom-fixed flex justify-end">
+        <Link href={`${pathname}/write`}>
+          <FloatAddButton />
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/articles/NoticeSection.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/articles/NoticeSection.client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import NoticeItem from './NoticeItem.client';
-import { useGetGroupDetail, useGetNotices } from '@/apis/groups';
+import { GroupDetailResponse, useGetNotices } from '@/apis/groups';
 import { useTranslation } from '@/app/i18n/client';
 import { Icon } from '@/components/Icon';
 import { Flex } from '@/components/Layout';
@@ -10,13 +10,12 @@ import { Spacing } from '@/components/Spacing';
 import { useNumberParams } from '@/hooks/useNumberParams';
 import { useBlockStore } from '@/store/useBlockStore';
 
-export default function NoticeSection() {
+interface NoticeSectionProps extends GroupDetailResponse {}
+
+export default function NoticeSection({ isCaptain }: NoticeSectionProps) {
   const { t } = useTranslation('groupDetail');
   const { blockNoticeIds } = useBlockStore();
   const { groupId } = useNumberParams<['groupId']>();
-
-  const { data: groupDetailData } = useGetGroupDetail(groupId);
-  const { isCaptain } = groupDetailData;
 
   const { data: noticesData } = useGetNotices(groupId);
 

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/articles/NoticeSection.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/articles/NoticeSection.client.tsx
@@ -27,18 +27,15 @@ export default function NoticeSection() {
       <div className="rounded-8 bg-card-ui p-16 text-subtitle-3 text-sign-secondary">
         <p className="pl-4">{t('board.notice')}</p>
         <Spacing size={6} />
-        {notices.length ? (
-          <ItemList
-            data={notices}
-            renderItem={(notice) =>
-              !blockNoticeIds.includes(notice.noticeId) && (
-                <NoticeItem notice={notice} groupId={groupId} isCaptain={isCaptain} />
-              )
-            }
-          />
-        ) : (
-          <EmptyNotice />
-        )}
+        <ItemList
+          data={notices}
+          renderItem={(notice) =>
+            !blockNoticeIds.includes(notice.noticeId) && (
+              <NoticeItem notice={notice} groupId={groupId} isCaptain={isCaptain} />
+            )
+          }
+          renderEmpty={() => <EmptyNotice />}
+        />
       </div>
     </section>
   );

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/articles/index.ts
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/articles/index.ts
@@ -1,2 +1,0 @@
-export { default as ArticleSection } from './ArticleSection.client';
-export { default as NoticeSection } from './NoticeSection.client';

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/detail/DetailContent.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/detail/DetailContent.client.tsx
@@ -1,0 +1,34 @@
+'use client';
+import LocationSection from './LocationSection.client';
+import MemberSection from './MemberSection.client';
+import TimeSection from './TimeSection.client';
+import { useGetGroupDetail } from '@/apis/groups';
+import { useTranslation } from '@/app/i18n/client';
+import { Button, ButtonGroup } from '@/components/Button';
+import { useNumberParams } from '@/hooks/useNumberParams';
+import { usePathname, useRouter } from 'next/navigation';
+import { Suspense } from 'react';
+
+export default function DetailContent() {
+  const { t } = useTranslation('groupDetail');
+  const { groupId } = useNumberParams<['groupId']>();
+  const pathname = usePathname();
+  const router = useRouter();
+  const { data: groupDetailData } = useGetGroupDetail(groupId);
+  const { isApplyWaited, myGroup } = groupDetailData;
+
+  return (
+    <Suspense>
+      <MemberSection {...groupDetailData} />
+      <TimeSection {...groupDetailData} />
+      <LocationSection {...groupDetailData} />
+      {!myGroup && (
+        <ButtonGroup>
+          <Button onClick={() => router.push(`${pathname}/apply`)} disabled={isApplyWaited}>
+            {t(isApplyWaited ? 'details.wait' : 'details.join')}
+          </Button>
+        </ButtonGroup>
+      )}
+    </Suspense>
+  );
+}

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/detail/DetailContent.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/detail/DetailContent.client.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from '@/app/i18n/client';
 import { Button, ButtonGroup } from '@/components/Button';
 import { useNumberParams } from '@/hooks/useNumberParams';
 import { usePathname, useRouter } from 'next/navigation';
-import { Suspense } from 'react';
 
 export default function DetailContent() {
   const { t } = useTranslation('groupDetail');
@@ -18,7 +17,7 @@ export default function DetailContent() {
   const { isApplyWaited, myGroup } = groupDetailData;
 
   return (
-    <Suspense>
+    <>
       <MemberSection {...groupDetailData} />
       <TimeSection {...groupDetailData} />
       <LocationSection {...groupDetailData} />
@@ -29,6 +28,6 @@ export default function DetailContent() {
           </Button>
         </ButtonGroup>
       )}
-    </Suspense>
+    </>
   );
 }

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/detail/LocationSection.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/detail/LocationSection.client.tsx
@@ -1,19 +1,23 @@
 'use client';
 
-import { useGetGroupDetail } from '@/apis/groups';
+import { GroupDetailResponse } from '@/apis/groups';
 import { useTranslation } from '@/app/i18n/client';
 import { Spacing } from '@/components/Spacing';
-import { useNumberParams } from '@/hooks/useNumberParams';
 import usePlaceDetails from '@/hooks/usePlaceDetails';
 import { GoogleMap, Marker } from '@react-google-maps/api';
 import { useParams } from 'next/navigation';
 
-export default function LocationSection() {
+interface LocationSectionProps extends GroupDetailResponse {}
+
+export default function LocationSection({
+  placeName,
+  placeLatitude,
+  placeLongitude,
+  placeAddress,
+  placeId,
+}: LocationSectionProps) {
   const { lng } = useParams() as { lng: string };
   const { t } = useTranslation('groupDetail');
-  const { groupId } = useNumberParams<['groupId']>();
-  const { data: groupDetailData } = useGetGroupDetail(groupId);
-  const { placeName, placeLatitude, placeLongitude, placeAddress, placeId } = groupDetailData;
   const { place } = usePlaceDetails({
     placeId,
     fields: ['name', 'formatted_address'],
@@ -21,8 +25,10 @@ export default function LocationSection() {
     region: 'KR',
   });
 
+  if (typeof google === 'undefined') return null;
+
   return (
-    <section>
+    <section className="p-20 pb-8">
       <h2 className="pl-4 text-subtitle-3 text-sign-secondary">{t('details.place')}</h2>
       <Spacing size={4} />
       <div className="relative overflow-hidden rounded-8 bg-divider">

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/detail/MemberSection.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/detail/MemberSection.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useGetGroupDetail, useGetGroupMembers } from '@/apis/groups';
+import { GroupDetailResponse, useGetGroupMembers } from '@/apis/groups';
 import { useTranslation } from '@/app/i18n/client';
 import { Avatar } from '@/components/Avatar';
 import { Icon } from '@/components/Icon';
@@ -9,20 +9,19 @@ import { Spacing } from '@/components/Spacing';
 import { useNumberParams } from '@/hooks/useNumberParams';
 import { usePathname, useRouter } from 'next/navigation';
 
-export default function MemberSection() {
+interface MemberSectionProps extends GroupDetailResponse {}
+
+export default function MemberSection({ memberCount, maxMemberCount }: MemberSectionProps) {
   const { t } = useTranslation('groupDetail');
   const { groupId } = useNumberParams<['groupId']>();
   const router = useRouter();
   const pathname = usePathname();
 
-  const { data: groupDetailData } = useGetGroupDetail(groupId);
-  const { memberCount, maxMemberCount } = groupDetailData;
-
   const { data: groupMembersData } = useGetGroupMembers(groupId);
   const { groupMembers } = groupMembersData;
 
   return (
-    <section>
+    <section className="p-20 pb-16">
       <div className="flex items-center justify-between">
         <p className="pl-4 text-subtitle-3 text-sign-secondary">
           {t('details.members', { memberCount, maxMemberCount })}

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/detail/TimeSection.client.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/detail/TimeSection.client.tsx
@@ -1,19 +1,16 @@
-import { useGetGroupDetail } from '@/apis/groups';
+import { GroupDetailResponse } from '@/apis/groups';
 import { useTranslation } from '@/app/i18n/client';
 import { Spacing } from '@/components/Spacing';
 import { TextField } from '@/components/TextField';
-import { useNumberParams } from '@/hooks/useNumberParams';
 import { formatMeetingDate } from '@/utils/formatMeetingDate';
 
-export default function TimeSection() {
-  const { t } = useTranslation('groupDetail');
-  const { groupId } = useNumberParams<['groupId']>();
-  const { data: groupDetailData } = useGetGroupDetail(groupId);
+interface TimeSectionProps extends GroupDetailResponse {}
 
-  const { meetDate, startTime } = groupDetailData;
+export default function TimeSection({ meetDate, startTime }: TimeSectionProps) {
+  const { t } = useTranslation('groupDetail');
 
   return (
-    <section>
+    <section className="p-20 pb-8">
       <p className="pl-4 text-subtitle-3 text-sign-secondary">{t('details.meetDate')}</p>
       <Spacing size={4} />
       <TextField

--- a/src/app/[lng]/(main)/grouping/[groupId]/components/detail/index.ts
+++ b/src/app/[lng]/(main)/grouping/[groupId]/components/detail/index.ts
@@ -1,3 +1,0 @@
-export { default as LocationSection } from './LocationSection.client';
-export { default as MemberSection } from './MemberSection.client';
-export { default as TimeSection } from './TimeSection.client';

--- a/src/app/[lng]/(main)/grouping/[groupId]/page.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/page.tsx
@@ -1,6 +1,6 @@
 import GroupDetailPage from './components/GroupDetail.client';
 import GroupDetailHeader from './components/GroupDetailHeader.client';
-import { Keys, getGroupDetail, getGroupMembers } from '@/apis/groups';
+import { Keys, getGroupDetail, getGroupMembers, getNotices } from '@/apis/groups';
 import { RejectedFallback } from '@/components/ErrorBoundary';
 import { Loading } from '@/components/Loading';
 import { PageAnimation } from '@/components/PageAnimation';
@@ -25,8 +25,16 @@ export default function GroupingDetailPage({ params }: GroupingDetailPageProps) 
       >
         <PageAnimation>
           <HydrationProvider
-            queryMultipleFn={[() => getGroupDetail(groupId), () => getGroupMembers(groupId)]}
-            queryMultipleKey={[Keys.getGroupDetail(groupId), Keys.getGroupMembers(groupId)]}
+            queryMultipleFn={[
+              () => getGroupDetail(groupId),
+              () => getGroupMembers(groupId),
+              () => getNotices(groupId),
+            ]}
+            queryMultipleKey={[
+              Keys.getGroupDetail(groupId),
+              Keys.getGroupMembers(groupId),
+              Keys.getNotices(groupId),
+            ]}
           >
             <GroupDetailPage />
           </HydrationProvider>

--- a/src/app/[lng]/(main)/grouping/[groupId]/page.tsx
+++ b/src/app/[lng]/(main)/grouping/[groupId]/page.tsx
@@ -28,7 +28,7 @@ export default function GroupingDetailPage({ params }: GroupingDetailPageProps) 
             queryMultipleFn={[() => getGroupDetail(groupId), () => getGroupMembers(groupId)]}
             queryMultipleKey={[Keys.getGroupDetail(groupId), Keys.getGroupMembers(groupId)]}
           >
-            <GroupDetailPage groupId={groupId} />
+            <GroupDetailPage />
           </HydrationProvider>
         </PageAnimation>
       </QueryAsyncBoundary>

--- a/src/app/[lng]/(main)/meeting/participate/components/ContentSection.client.tsx
+++ b/src/app/[lng]/(main)/meeting/participate/components/ContentSection.client.tsx
@@ -4,8 +4,9 @@ import ParticipatingContent from './ParticipatingContent.client';
 import WaitingContent from './WaitingContent.client';
 import { useTranslation } from '@/app/i18n/client';
 import { Tabs } from '@/components/Tabs';
+import { Suspense } from 'react';
 
-export default function ContentTabs() {
+export default function ContentSection() {
   const { t } = useTranslation('meeting');
 
   return (
@@ -16,13 +17,19 @@ export default function ContentTabs() {
         <Tabs.Tab value="feedback" text={t('home.evaluation')} />
       </Tabs.List>
       <Tabs.Panel value="participating">
-        <ParticipatingContent />
+        <Suspense>
+          <ParticipatingContent />
+        </Suspense>
       </Tabs.Panel>
       <Tabs.Panel value="waiting">
-        <WaitingContent />
+        <Suspense>
+          <WaitingContent />
+        </Suspense>
       </Tabs.Panel>
       <Tabs.Panel value="feedback">
-        <FeedbackContent />
+        <Suspense>
+          <FeedbackContent />
+        </Suspense>
       </Tabs.Panel>
     </Tabs>
   );

--- a/src/app/[lng]/(main)/meeting/participate/page.tsx
+++ b/src/app/[lng]/(main)/meeting/participate/page.tsx
@@ -32,13 +32,11 @@ export default function MeetingPage({ params: { lng } }: MeetingPageProps) {
               getMeetingHosting,
               getMeetingRejected,
               getMeetingNotEstimated,
-              getMeetingNotEstimated,
             ]}
-            queryKey={[
+            queryMultipleKey={[
               Keys.getMeetingParticipating(),
               Keys.getMeetingHosting(),
               Keys.getMeetingRejected(),
-              Keys.getMeetingNotEstimated(),
               Keys.getMeetingNotEstimated(),
             ]}
           >

--- a/src/app/[lng]/(main)/meeting/scrap/components/ContentSection.client.tsx
+++ b/src/app/[lng]/(main)/meeting/scrap/components/ContentSection.client.tsx
@@ -4,7 +4,6 @@ import { useGetMeetingScrap } from '@/apis/meeting';
 import { useTranslation } from '@/app/i18n/client';
 import { GroupingCard } from '@/components/Card';
 import { ItemList } from '@/components/List';
-import { Fragment } from 'react';
 
 export default function ContentSection() {
   const { t } = useTranslation('meeting');
@@ -13,12 +12,10 @@ export default function ContentSection() {
   } = useGetMeetingScrap();
 
   return (
-    <Fragment>
-      {contents.length === 0 && <NoMeeting message={t('home.noFavoritedGroups')} />}
-      <ItemList
-        data={contents}
-        renderItem={(content) => <GroupingCard groupingData={content} isScrapped />}
-      />
-    </Fragment>
+    <ItemList
+      data={contents}
+      renderItem={(content) => <GroupingCard groupingData={content} isScrapped />}
+      renderEmpty={() => <NoMeeting message={t('home.noFavoritedGroups')} />}
+    />
   );
 }

--- a/src/app/[lng]/(main)/profile/setting/page.tsx
+++ b/src/app/[lng]/(main)/profile/setting/page.tsx
@@ -1,6 +1,7 @@
 import LinkSection from './components/LinkSection.server';
 import ProfileSection from './components/ProfileSection.client';
 import SettingHeader from './components/SettingHeader';
+import { Suspense } from 'react';
 
 interface PageParams {
   params: {
@@ -12,7 +13,9 @@ export default function page({ params: { lng } }: PageParams) {
   return (
     <>
       <SettingHeader />
-      <ProfileSection />
+      <Suspense fallback={<div>Loading...</div>}>
+        <ProfileSection />
+      </Suspense>
       <LinkSection lng={lng} />
     </>
   );

--- a/src/app/[lng]/(main)/profile/setting/page.tsx
+++ b/src/app/[lng]/(main)/profile/setting/page.tsx
@@ -1,7 +1,9 @@
 import LinkSection from './components/LinkSection.server';
 import ProfileSection from './components/ProfileSection.client';
 import SettingHeader from './components/SettingHeader';
-import { Suspense } from 'react';
+import { RejectedFallback } from '@/components/ErrorBoundary';
+import { PageAnimation } from '@/components/PageAnimation';
+import { QueryAsyncBoundary } from '@suspensive/react-query';
 
 interface PageParams {
   params: {
@@ -13,10 +15,12 @@ export default function page({ params: { lng } }: PageParams) {
   return (
     <>
       <SettingHeader />
-      <Suspense fallback={<div>Loading...</div>}>
-        <ProfileSection />
-      </Suspense>
-      <LinkSection lng={lng} />
+      <QueryAsyncBoundary rejectedFallback={RejectedFallback}>
+        <PageAnimation>
+          <ProfileSection />
+          <LinkSection lng={lng} />
+        </PageAnimation>
+      </QueryAsyncBoundary>
     </>
   );
 }

--- a/src/components/List/ItemList.tsx
+++ b/src/components/List/ItemList.tsx
@@ -5,6 +5,7 @@ import { ComponentProps, Fragment } from 'react';
 interface ItemListProps<T> extends Omit<ComponentProps<typeof Flex>, 'children'> {
   data: T[];
   renderItem: (data: T) => JSX.Element | boolean | null | undefined;
+  renderEmpty?: () => JSX.Element | boolean | null | undefined;
   direction?: 'row' | 'column';
   className?: string;
   hasDivider?: boolean;
@@ -13,6 +14,7 @@ interface ItemListProps<T> extends Omit<ComponentProps<typeof Flex>, 'children'>
 export default function ItemList<T>({
   data,
   renderItem,
+  renderEmpty,
   direction = 'column',
   className,
   hasDivider = true,
@@ -20,14 +22,16 @@ export default function ItemList<T>({
 }: ItemListProps<T>) {
   return (
     <Flex direction={direction} className={className} {...props}>
-      {data.map((item, index) => {
-        return (
-          <Fragment key={index}>
-            {renderItem(item)}
-            {renderItem(item) && hasDivider && index !== data.length - 1 && <Divider />}
-          </Fragment>
-        );
-      })}
+      {data.length === 0
+        ? renderEmpty?.()
+        : data.map((item, index) => {
+            return (
+              <Fragment key={index}>
+                {renderItem(item)}
+                {renderItem(item) && hasDivider && index !== data.length - 1 && <Divider />}
+              </Fragment>
+            );
+          })}
     </Flex>
   );
 }

--- a/src/components/Provider/HydrationProvider.tsx
+++ b/src/components/Provider/HydrationProvider.tsx
@@ -25,10 +25,13 @@ export default async function HydrationProvider({
   const queryClient = getQueryClient();
 
   if (queryMultipleFn && queryMultipleKey) {
-    queryMultipleFn.forEach(async (queryFn, index) => {
-      await queryClient.prefetchQuery(queryMultipleKey[index], queryFn);
-    });
+    await Promise.all(
+      queryMultipleFn.map((queryFn, index) => {
+        return queryClient.prefetchQuery(queryMultipleKey[index], queryFn);
+      })
+    );
   }
+
   if (queryFn && queryKey) {
     if (isInfiniteQuery) await queryClient.prefetchInfiniteQuery(queryKey, queryFn);
     else await queryClient.prefetchQuery(queryKey, queryFn);


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 신규 피처
- close #446
## 💁 무엇이 어떻게 바뀌나요?

1. 나의 모임 페이지 및 설정 페이지에서 나타난 무한 요청 이슈를 해결했습니다.

### Hydration 문제

```tsx
// HydrationProvider.tsx
queryMultipleFn.forEach(async (queryFn, index) => {
  await queryClient.prefetchQuery(queryMultipleKey[index], queryFn);
});
```

여러개의 쿼리가 hydration될 때 forEach로 비동기 콜백함수를 넣어주고 있었습니다.

하지만 forEach는 비동기 콜백을 기다려주지 않아서 dehydrtate가 예상과 다르게 동작하고 있습니다.

그래서 forEach 대신 `Promise.all`로 처리했습니다. `for...of`도 가능합니다.

### Tabs 컴포넌트를 사용할 때 Panel이 변경되어도 Suspense가 인식하지 못하고 있음

현재 Tab을 클릭하면 쿼리스트링이 변경되면서 컨텐츠가 바뀌는 형식입니다.

이 때 page에 있는 Suspense가 변경됨을 인식하지 못하는 것 같습니다. 현재 여러 테스트를 해보면서 원인을 파악하는 중입니다.

해결 방법은 Panel 컨텐츠에 각각 Suspense를 감싸도록 처리하여 해결했습니다.

### 설정페이지 무한 요청 이슈

설정 페이지에 Suspense로 감싸지 않아 발생한 문제였습니다. 해당 부분 추가하여 해결했습니다.




## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
