### PR TITLE
fix: 언어 올바르게 띄워지도록 수정 및 로그인, 회원가입 시 로딩 레이어 띄워지도록 변경

### DIFF
--- a/src/app/[lng]/(main)/profile/setting/delete/components/Step1.tsx
+++ b/src/app/[lng]/(main)/profile/setting/delete/components/Step1.tsx
@@ -18,6 +18,7 @@ const infoList = [
 
 export default function Step1({ onNextClick }: Step1Props) {
   const { t } = useTranslation('profile');
+  const { t: tc } = useTranslation('common');
   const { setValue, watch } = useDeleteContext();
   const handleDeleteAgree = () => {
     setValue('isDeleteAgree', !watch('isDeleteAgree'));
@@ -44,7 +45,7 @@ export default function Step1({ onNextClick }: Step1Props) {
 
       <ButtonGroup>
         <Button onClick={onNextClick} disabled={!watch('isDeleteAgree')}>
-          {t('next')}
+          {tc('next')}
         </Button>
       </ButtonGroup>
     </div>

--- a/src/app/[lng]/(sub)/join/funnels/step1/components/NumberVerifyForm.client.tsx
+++ b/src/app/[lng]/(sub)/join/funnels/step1/components/NumberVerifyForm.client.tsx
@@ -4,6 +4,7 @@ import { formatWithoutHyphen } from '../util';
 import { LoginResponse, useLoginMutation, useSMSMutation, useSMSVerifyMutation } from '@/apis/auth';
 import { useTranslation } from '@/app/i18n/client';
 import { Button, ButtonGroup } from '@/components/Button';
+import { LayerLoading } from '@/components/Loading';
 import { useTimerContext } from '@/components/Provider';
 import { TextFieldController } from '@/components/TextField';
 import { regexr } from '@/constants/regexr';
@@ -26,7 +27,7 @@ export default function NumberVerifyForm({ setInputStatus }: NumberVerifyFormPro
 
   const { nextStep } = useFunnelContext();
   const { mutate: mutateSMSVerify } = useSMSVerifyMutation();
-  const { mutate: mutateLogin } = useLoginMutation();
+  const { mutate: mutateLogin, status } = useLoginMutation();
   const { mutate: mutateSMS } = useSMSMutation();
 
   const handleResend = () => {
@@ -116,6 +117,7 @@ export default function NumberVerifyForm({ setInputStatus }: NumberVerifyFormPro
         </Button>
         <Button type="submit">{t('complete')}</Button>
       </ButtonGroup>
+      <LayerLoading isLoading={status === 'loading' || status === 'success'} />
     </form>
   );
 }

--- a/src/app/[lng]/(sub)/join/funnels/step5/components/InputForm.client.tsx
+++ b/src/app/[lng]/(sub)/join/funnels/step5/components/InputForm.client.tsx
@@ -4,6 +4,7 @@ import { useJoinContext } from '../../../components/JoinContext.client';
 import { useSignUpMutation } from '@/apis/auth';
 import { useTranslation } from '@/app/i18n/client';
 import { Button, ButtonGroup } from '@/components/Button';
+import { LayerLoading } from '@/components/Loading';
 import { Tag } from '@/components/Tag';
 import { personalityList } from '@/constants/personalityList';
 import { formatDateDTO } from '@/utils/formatDateDTO';
@@ -15,14 +16,14 @@ export default function InputForm() {
   const { t } = useTranslation('join');
 
   const { handleSubmit, watch } = useJoinContext();
-  const { mutate: mutateSignUp } = useSignUpMutation();
+  const { mutate: mutateSignUp, status } = useSignUpMutation();
 
   const onSubmit = async (data: SignUpState) => {
     const { verifyEmailNumber, verifyNumber, birth, personalityIdList, ...rest } = data;
     const signUpRequest = {
       ...rest,
       birth: formatDateDTO(birth),
-      personalities: personalityIdList.map((id) => personalityList[id].keywordDTO),
+      personalities: personalityIdList.map((id) => personalityList[id]?.keywordDTO),
     };
     mutateSignUp(signUpRequest);
   };
@@ -35,6 +36,7 @@ export default function InputForm() {
           {t('complete')}
         </Button>
       </ButtonGroup>
+      <LayerLoading isLoading={status === 'loading' || status === 'success'} />
     </form>
   );
 }

--- a/src/app/i18n/client.ts
+++ b/src/app/i18n/client.ts
@@ -3,7 +3,9 @@
 
 import { getOptions, languages } from './settings';
 import i18next from 'i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
 import resourcesToBackend from 'i18next-resources-to-backend';
+import { useParams } from 'next/navigation';
 import { initReactI18next, useTranslation as useTranslationOrg } from 'react-i18next';
 // import LocizeBackend from 'i18next-locize-backend'
 
@@ -11,6 +13,7 @@ const runsOnServerSide = typeof window === 'undefined';
 
 i18next
   .use(initReactI18next)
+  .use(LanguageDetector)
   .use(
     resourcesToBackend(
       (language: string, namespace: string) => import(`./locales/${language}/${namespace}.json`)
@@ -27,7 +30,12 @@ i18next
   });
 
 export function useTranslation(ns: string, options: { keyPrefix?: string } = {}) {
+  const params = useParams() as { lng: string };
   const ret = useTranslationOrg(ns, options);
+
+  if (runsOnServerSide) {
+    ret.i18n.changeLanguage(params.lng);
+  }
 
   return ret;
 }


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- close #478 

## 💁 무엇이 어떻게 바뀌나요?

1. 언어 올바르게 띄워지도록 수정
2. 로그인, 회원가입 시 로딩 레이어 띄워지도록 변경
3. 탈퇴 페이지 `다음` 버튼 번역 오류 수정

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->

헤더가 클라이언트 컴포넌트일 때 i18n의 client 훅을 호출하고 있습니다. 하지만 서버 사이드에서 client 훅이 호출되는 경우가 있어서 params로 언어를 판단하도록 변경했습니다.

그리고 `LanguageDetector`를 추가하여 클라이언트 사이드일 때 `detection`에 적은 order가 제대로 적용될 수 있도록 했습니다.