### PR TITLE
fix: underline shift 현상 해결

### DIFF
--- a/src/components/Tabs/Tabs.client.tsx
+++ b/src/components/Tabs/Tabs.client.tsx
@@ -117,9 +117,9 @@ function Tab({ value, text, queryString, className, disabled = false }: TabProps
       {isActive && (
         <motion.span
           layout
-          layoutRoot
           layoutId="underline"
-          className="absolute bottom-0 left-0 w-full border-b-1 border-primary text-subtitle-2 text-primary"
+          style={{ originY: '0px' }}
+          className=" absolute bottom-0 left-0 w-full border-b-1 border-primary text-subtitle-2 text-primary"
         />
       )}
     </Link>


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 신규 피처

## 💁 무엇이 어떻게 바뀌나요?

1. 스크롤 후 탭 변경 시 `underline` 애니메이션이 아래에서 올라오는 문제가 있었는데, [stackoverflow](https://stackoverflow.com/questions/76662555/framer-motion-single-axis-layout-animations-on-fixed-element)에서 해결책을 찾아 해결했습니다.

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->

### 변경 전
![a](https://github.com/gloddy-dev/gloddy-client/assets/23312485/a827feec-8edd-4ac0-bd5d-a3717fc0fe5b)

### 변경 후

![b](https://github.com/gloddy-dev/gloddy-client/assets/23312485/56805a03-fb6e-4a2c-aa78-7e34f1e65c81)

