### PR TITLE
Feature: QueryProvider, ModalProvider 이슈해결

### DIFF
--- a/src/app/[lng]/(main)/grouping/create/funnels/main/MainStep.client.tsx
+++ b/src/app/[lng]/(main)/grouping/create/funnels/main/MainStep.client.tsx
@@ -6,11 +6,10 @@ import CreateModal from '../../components/CreateModal.client';
 import { useTranslation } from '@/app/i18n/client';
 import { Button, ButtonGroup } from '@/components/Button';
 import { Divider } from '@/components/Divider';
-import { Toast } from '@/components/Modal';
 import { Spacing } from '@/components/Spacing';
 import { useDidMount } from '@/hooks/common/useDidMount';
 import useBrowser from '@/hooks/useBrowser';
-import { useModal } from '@/hooks/useModal';
+import { useModal, useToast } from '@/hooks/useModal';
 import sendMessageToReactNative from '@/utils/sendMessageToReactNative';
 import { format } from 'date-fns';
 
@@ -48,7 +47,7 @@ export default function MainStep({ onSelectMeetDate, onCreateSubmit }: MainStepP
 
   const { t } = useTranslation('grouping');
   const { open: openCreateModal, exit: exitCreateModal } = useModal();
-  const { open: openToast } = useModal({ delay: 2000 });
+  const { openToast } = useToast();
 
   const isAllInput = Object.values(hookForm.watch()).every((value) => {
     if (typeof value === 'object') {
@@ -59,7 +58,7 @@ export default function MainStep({ onSelectMeetDate, onCreateSubmit }: MainStepP
 
   const handleCreateClick = () => {
     if (!validateDate(watch('meetDate'), watch('time'), browser)) {
-      openToast(() => <Toast>{t('create.error.time')}</Toast>);
+      openToast(t('create.error.time'));
       return;
     }
 

--- a/src/app/[lng]/(sub)/join/funnels/step1/components/NumberForm.client.tsx
+++ b/src/app/[lng]/(sub)/join/funnels/step1/components/NumberForm.client.tsx
@@ -3,13 +3,12 @@ import { formatNumber, formatNumberBackSpace } from '../util';
 import { LoginResponse, useLoginMutation, useSMSMutation } from '@/apis/auth';
 import { useTranslation } from '@/app/i18n/client';
 import { Button, ButtonGroup } from '@/components/Button';
-import { Toast } from '@/components/Modal';
 import { useTimerContext } from '@/components/Provider';
 import { Spacing } from '@/components/Spacing';
 import { TextFieldController } from '@/components/TextField';
 import { regexr } from '@/constants/regexr';
 import useAppRouter from '@/hooks/useAppRouter';
-import { useModal } from '@/hooks/useModal';
+import { useToast } from '@/hooks/useModal';
 import { setTokenAtCookie } from '@/utils/auth/tokenController';
 import { ElementType, KeyboardEventHandler } from 'react';
 
@@ -28,7 +27,7 @@ export default function NumberForm({ inputStatus, setInputStatus }: NumberSectio
   const { setValue, handleSubmit, register, formState } = hookForm;
   const { mutate: mutateSMS } = useSMSMutation();
   const { start: timerStart, status: timerStatus } = useTimerContext();
-  const { open: openToast } = useModal({ delay: 2000 });
+  const { openToast } = useToast();
   const { mutate: mutateLogin } = useLoginMutation();
   const { refresh, replace } = useAppRouter();
 
@@ -67,7 +66,7 @@ export default function NumberForm({ inputStatus, setInputStatus }: NumberSectio
       return;
     }
     mutateSMS({ number: phoneNumberWithoutHyphen });
-    openToast(() => <Toast>인증 번호가 전송되었습니다.</Toast>);
+    openToast('인증 번호가 전송되었습니다.');
     setInputStatus('afterSend');
   };
 

--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -5,6 +5,7 @@ import { GoogleAnalytics } from '@/components/Analytics';
 import { InitMap } from '@/components/Map';
 import { QueryProvider } from '@/components/Provider';
 import QueryProviderWrapModal from '@/components/Provider/QueryProviderWrapModal.client';
+import ToastProvider from '@/components/Provider/ToastProvider';
 import { BASE_WEB_URL, GOOGLE_API_KEY } from '@/constants';
 import ModalProvider from '@/hooks/useModal/ModalProvider';
 import { dir } from 'i18next';
@@ -57,14 +58,14 @@ export default function RootLayout({
 }: StrictPropsWithChildren<RootLayoutProps>) {
   return (
     <Layout lng={lng}>
-      <QueryProviderWrapModal>
-        <ModalProvider>
-          <QueryProvider>
+      <ToastProvider>
+        <QueryProvider>
+          <ModalProvider>
             <GoogleAnalytics />
             {children}
-          </QueryProvider>
-        </ModalProvider>
-      </QueryProviderWrapModal>
+          </ModalProvider>
+        </QueryProvider>
+      </ToastProvider>
       <InitMap />
       <Script
         defer

--- a/src/components/Provider/QueryProvider.client.tsx
+++ b/src/components/Provider/QueryProvider.client.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable react/jsx-no-useless-fragment */
 'use client';
 
-import { Toast } from '@/components/Modal';
-import { useModal } from '@/hooks/useModal';
+import { useToast } from '@/hooks/useModal';
 import * as Sentry from '@sentry/nextjs';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -10,7 +9,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { StrictPropsWithChildren } from '@/types';
 
 export default function QueryProvider({ children }: StrictPropsWithChildren) {
-  const { open } = useModal({ delay: 2000 });
+  const { openToast } = useToast();
 
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -23,11 +22,7 @@ export default function QueryProvider({ children }: StrictPropsWithChildren) {
         onError: (error) => {
           const errorMessage =
             typeof error === 'string' ? error : '오류가 발생했습니다. 다시 시도해주세요.';
-          open(() => (
-            <Toast>
-              <>{errorMessage}</>
-            </Toast>
-          ));
+          openToast(errorMessage);
         },
       },
     },

--- a/src/components/Provider/ToastProvider.tsx
+++ b/src/components/Provider/ToastProvider.tsx
@@ -1,0 +1,6 @@
+import { ModalProvider } from '@/hooks/useModal';
+import { StrictPropsWithChildren } from '@/types';
+
+export default function ToastProvider({ children }: StrictPropsWithChildren) {
+  return <ModalProvider>{children}</ModalProvider>;
+}

--- a/src/hooks/useModal/index.ts
+++ b/src/hooks/useModal/index.ts
@@ -1,2 +1,3 @@
 export { default as ModalProvider } from './ModalProvider';
 export { default as useModal } from './useModal';
+export { default as useToast } from './useToast';

--- a/src/hooks/useModal/useToast.tsx
+++ b/src/hooks/useModal/useToast.tsx
@@ -1,0 +1,8 @@
+import useModal from './useModal';
+import { Toast } from '@/components/Modal';
+
+export default function useToast() {
+  const { open, close, exit } = useModal({ delay: 2000 });
+  const openToast = (message: string) => open(() => <Toast>{message}</Toast>);
+  return { openToast, close, exit };
+}


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 신규 피처
- close #544

## 💁 무엇이 어떻게 바뀌나요?

1. 기존 방식은 QueryProvider > ModalProvider > QueryProvider방식이었습니다. 이는 ModalProvider 내부에서 Query요청을 해야 할 일이 있고, 또한 QueryProvider내부에서 Modal을 이용한 토스트를 띄워야하기에 만들어진 구조였습니다.
QueryProvider에서 사용하는 QueryClientProvider는 내부적으로 QueryClient를 `useContext`로 관리하는 형태입니다. 이 QueryProvider를 바깥에 한 번, 안에 두 번 감싸게 될 경우 상태 관리에 혼란을 일으킬 수 있다는 점, 리렌더링으로 인해 성능 이슈가 발생할수 있다위험이 존재했습니다.

이에 따라, Toast만을 사용할 수 있는 ToastProvider를 만들어 가장 바깥에 감쌌습니다.

또한, Toast를 useModal을 사용하던 방식 -> useToast훅을 별도로 만들어서 보다 선언적으로, 그리고 쉽게 Toast를 관리할 수 있도록 하였습니다.

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
