### PR TITLE
Fix: 모임 생성 페이지 X 버튼 app router로 수정

### DIFF
--- a/src/app/[lng]/(main)/grouping/create/components/CreateHeader.client.tsx
+++ b/src/app/[lng]/(main)/grouping/create/components/CreateHeader.client.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from '@/app/i18n/client';
 import { IconButton } from '@/components/Button';
 import { Header } from '@/components/Header';
 import { Icon } from '@/components/Icon';
-import { useRouter } from 'next/navigation';
+import useAppRouter from '@/hooks/useAppRouter';
 
 interface CreateHeaderProps {
   currentStep: 'main' | 'meetDate';
@@ -10,12 +10,12 @@ interface CreateHeaderProps {
 
 export default function CreateHeader({ currentStep }: CreateHeaderProps) {
   const { t } = useTranslation('grouping');
-  const { back } = useRouter();
+  const { back } = useAppRouter();
 
   return (
     <Header className="px-4">
       <Header.Left>
-        <IconButton size="large" onClick={back}>
+        <IconButton size="large" onClick={() => back()}>
           <Icon id="24-close" />
         </IconButton>
         {currentStep === 'main' && <p>{t('create.headerTitle')}</p>}

--- a/src/app/[lng]/(main)/grouping/create/components/CreateHeader.client.tsx
+++ b/src/app/[lng]/(main)/grouping/create/components/CreateHeader.client.tsx
@@ -15,7 +15,7 @@ export default function CreateHeader({ currentStep }: CreateHeaderProps) {
   return (
     <Header className="px-4">
       <Header.Left>
-        <IconButton size="large" onClick={() => back()}>
+        <IconButton size="large" onClick={back}>
           <Icon id="24-close" />
         </IconButton>
         {currentStep === 'main' && <p>{t('create.headerTitle')}</p>}


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 버그 수정
- #557 

## 💁 무엇이 어떻게 바뀌나요?

1. 모임생성 페이지 Header의 next/Router의 back 함수를 useAppRouter의 back 함수로 교체했습니다. 

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
