### PR TITLE
Hotfix: 국가설정이 안된 유저는 국기 이미지 노출 제거(임시)

### DIFF
--- a/src/app/[lng]/(main)/profile/components/ProfileDetailSection.client.tsx
+++ b/src/app/[lng]/(main)/profile/components/ProfileDetailSection.client.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { motion } from 'framer-motion';
+import Image from 'next/image';
+import { useParams, usePathname } from 'next/navigation';
+
 import { useGetProfileById } from '@/apis/profile';
 import { useTranslation } from '@/app/i18n/client';
 import { Avatar } from '@/components/Avatar';
@@ -14,9 +18,6 @@ import { personalityList } from '@/constants/personalityList';
 import { reliabilities } from '@/constants/reliabilities';
 import useAppRouter from '@/hooks/useAppRouter';
 import cn from '@/utils/cn';
-import { motion } from 'framer-motion';
-import Image from 'next/image';
-import { useParams, usePathname } from 'next/navigation';
 
 interface ProfileDetailProps {
   profileData: ReturnType<typeof useGetProfileById>['data'];
@@ -84,9 +85,11 @@ export default function ProfileDetailSection({ profileData }: ProfileDetailProps
           </Avatar>
           <Spacing size={16} />
           <h4 className="relative flex items-center gap-5 text-h4">
-            <div className="relative h-16 w-24">
-              <Image src={countryImage} fill className="object-fill" alt="국가" />
-            </div>
+            {countryImage && (
+              <div className="relative h-16 w-24">
+                <Image src={countryImage} fill className="object-fill" alt="국가" />
+              </div>
+            )}
             <span>{nickname}</span>
             <Icon
               id={`16-reliability-${reliabilityLevel.toLowerCase()}`}


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 이슈대응
- #570 
## 💁 무엇이 어떻게 바뀌나요?

1. 기존에 회원가입한 국가를 설정하지 않은 유저는 국기 이미지를 로딩하지 않게 임시로 막아두었습니다.
2.
3.

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
