### PR TITLE
Feature : 에러 핸들링

### DIFF
--- a/src/app/[lng]/(main)/error.tsx
+++ b/src/app/[lng]/(main)/error.tsx
@@ -1,9 +1,15 @@
 'use client';
 
 import BaseError, { BaseErrorProps } from '@/components/Error/BaseError';
+import { Footer } from '@/components/Footer';
 
 interface ErrorProps extends BaseErrorProps {}
 
 export default function Error({ error, reset }: ErrorProps) {
-  return <BaseError error={error} reset={reset} />;
+  return (
+    <>
+      <BaseError error={error} reset={reset} />
+      <Footer lng="ko" />
+    </>
+  );
 }

--- a/src/components/Error/BaseError.tsx
+++ b/src/components/Error/BaseError.tsx
@@ -1,5 +1,7 @@
 import { Flex } from '@/components/Layout';
 import { Spacing } from '@/components/Spacing';
+import { removeToken } from '@/utils/auth/tokenController';
+import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
 export interface BaseErrorProps {
@@ -8,9 +10,15 @@ export interface BaseErrorProps {
 }
 
 export default function BaseError({ error, reset }: BaseErrorProps) {
+  const router = useRouter();
   useEffect(() => {
     console.error(error);
   }, [error]);
+
+  const handleLogOut = () => {
+    router.push('/join');
+    removeToken();
+  };
 
   return (
     <Flex align="center" justify="center" className="h-full text-sign-tertiary " direction="column">
@@ -29,6 +37,12 @@ export default function BaseError({ error, reset }: BaseErrorProps) {
         onClick={reset}
       >
         다시 불러오기
+      </button>
+      <button
+        className="bg-grey-200 text-13 mt-16 block rounded-lg px-12 py-8 font-bold text-red-300"
+        onClick={handleLogOut}
+      >
+        로그아웃하기
       </button>
     </Flex>
   );

--- a/src/components/Error/BaseError.tsx
+++ b/src/components/Error/BaseError.tsx
@@ -1,0 +1,35 @@
+import { Flex } from '@/components/Layout';
+import { Spacing } from '@/components/Spacing';
+import { useEffect } from 'react';
+
+export interface BaseErrorProps {
+  error: Error;
+  reset: () => void;
+}
+
+export default function BaseError({ error, reset }: BaseErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <Flex align="center" justify="center" className="h-full text-sign-tertiary " direction="column">
+      <p className="text-30 flex h-48 w-48 items-center justify-center rounded-full bg-sign-caption text-white">
+        X
+      </p>
+      <Spacing size={20} />
+      <p className="text-center text-subtitle-1">
+        오류가 발생했습니다.
+        <br />
+        잠시 후 다시 시도해 주세요.
+      </p>
+      <p>{error.message}</p>
+      <button
+        className="bg-grey-200 text-13 mt-16 block rounded-lg px-12 py-8 font-bold"
+        onClick={reset}
+      >
+        다시 불러오기
+      </button>
+    </Flex>
+  );
+}

--- a/src/components/Error/index.ts
+++ b/src/components/Error/index.ts
@@ -1,0 +1,1 @@
+export { default as Error } from './BaseError';

--- a/src/utils/auth/tokenController.ts
+++ b/src/utils/auth/tokenController.ts
@@ -61,3 +61,7 @@ export const hasToken = () => {
 
   return accessToken || refreshToken;
 };
+
+export const removeToken = () => {
+  setTokenAtCookie({ accessToken: '', refreshToken: '', userId: 0 });
+};


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 신규 피처
- close #575

## 💁 무엇이 어떻게 바뀌나요?

1. 에러핸들링하는 `error.tsx`를 BaseError공통컴포넌트를 만들어 공통으로 관리합니다. 그리고, reset버튼을 추가하여 사용자가 새로고침할 수 있도록, 로그아웃 버튼으로 다시 로그인을 할 수 있도록, 그리고 Footer컴포넌트를 추가하여 다른 페이지로 이동할 수 있도록 추가하여 더 넓은 선택지를 주었습니다.

### 작성한 문서 : [브라우저에서 에러 페이지를 어떻게 보여줄 수 있을까](https://www.notion.so/guesung/c932c60c941e482888cefe4b6209d365?pvs=4)

![image](https://github.com/gloddy-dev/gloddy-client/assets/62178788/929be555-d776-4bc2-a281-57cbaebf1cca)



## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
