### PR TITLE
Feature : NextJS의 Footer에서 React Native의 TabBar로 교체

### DIFF
--- a/src/apis/auth/mutations.ts
+++ b/src/apis/auth/mutations.ts
@@ -10,6 +10,7 @@ import {
 } from '.';
 import useAppRouter from '@/hooks/useAppRouter';
 import { setTokenAtCookie } from '@/utils/auth/tokenController';
+import sendMessageToReactNative from '@/utils/sendMessageToReactNative';
 import { useMutation } from '@tanstack/react-query';
 
 export const useLoginMutation = () => useMutation({ mutationFn: postLogin });
@@ -29,6 +30,7 @@ export const useSignUpMutation = () => {
   return useMutation({
     mutationFn: postSignUp,
     onSuccess: (data: SignUpResponse) => {
+      sendMessageToReactNative({ type: 'SIGN_IN', data: 'LOGIN_SUCCESS' });
       const {
         userId,
         token: { accessToken, refreshToken },

--- a/src/app/[lng]/(main)/community/page.tsx
+++ b/src/app/[lng]/(main)/community/page.tsx
@@ -1,13 +1,13 @@
-import { Suspense } from 'react';
-
 import CommunityHeader from './components/CommunityHeader';
 import ContentSection from './components/ContentSection.client';
 import { Keys, getCommunityArticles } from '@/apis/community';
-import { Footer } from '@/components/Footer';
 import { Loading } from '@/components/Loading';
 import { HydrationProvider } from '@/components/Provider';
 import { Spacing } from '@/components/Spacing';
+import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
 
+const Footer = dynamic(() => import('@/components/Footer/Footer.server'), { ssr: false });
 interface CommunityPageProps {
   params: {
     lng: string;

--- a/src/app/[lng]/(main)/community/page.tsx
+++ b/src/app/[lng]/(main)/community/page.tsx
@@ -7,7 +7,7 @@ import { Spacing } from '@/components/Spacing';
 import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
 
-const Footer = dynamic(() => import('@/components/Footer/Footer.server'), { ssr: false });
+const Footer = dynamic(() => import('@/components/Footer/Footer'), { ssr: false });
 interface CommunityPageProps {
   params: {
     lng: string;

--- a/src/app/[lng]/(main)/error.tsx
+++ b/src/app/[lng]/(main)/error.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import BaseError, { BaseErrorProps } from '@/components/Error/BaseError';
-import { Footer } from '@/components/Footer';
+import dynamic from 'next/dynamic';
+
+const Footer = dynamic(() => import('@/components/Footer/Footer.server'), { ssr: false });
 
 interface ErrorProps extends BaseErrorProps {}
 

--- a/src/app/[lng]/(main)/error.tsx
+++ b/src/app/[lng]/(main)/error.tsx
@@ -3,7 +3,7 @@
 import BaseError, { BaseErrorProps } from '@/components/Error/BaseError';
 import dynamic from 'next/dynamic';
 
-const Footer = dynamic(() => import('@/components/Footer/Footer.server'), { ssr: false });
+const Footer = dynamic(() => import('@/components/Footer/Footer'), { ssr: false });
 
 interface ErrorProps extends BaseErrorProps {}
 

--- a/src/app/[lng]/(main)/grouping/page.tsx
+++ b/src/app/[lng]/(main)/grouping/page.tsx
@@ -2,11 +2,13 @@ import CreateGroupButton from './components/CreateGroupButton.client';
 import GroupingCardList from './components/GroupingCardList.client';
 import GroupingHeader from './components/GroupingHeader';
 import { Keys, getGroups } from '@/apis/groups';
-import { Footer } from '@/components/Footer';
 import { Loading } from '@/components/Loading';
 import { HydrationProvider } from '@/components/Provider';
 import { Spacing } from '@/components/Spacing';
+import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
+
+const Footer = dynamic(() => import('@/components/Footer/Footer.server'), { ssr: false });
 
 interface GroupingPageProps {
   params: {

--- a/src/app/[lng]/(main)/grouping/page.tsx
+++ b/src/app/[lng]/(main)/grouping/page.tsx
@@ -8,7 +8,7 @@ import { Spacing } from '@/components/Spacing';
 import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
 
-const Footer = dynamic(() => import('@/components/Footer/Footer.server'), { ssr: false });
+const Footer = dynamic(() => import('@/components/Footer/Footer'), { ssr: false });
 
 interface GroupingPageProps {
   params: {

--- a/src/app/[lng]/(main)/meeting/participate/page.tsx
+++ b/src/app/[lng]/(main)/meeting/participate/page.tsx
@@ -13,7 +13,7 @@ import { HydrationProvider } from '@/components/Provider';
 import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
 
-const Footer = dynamic(() => import('@/components/Footer/Footer.server'), { ssr: false });
+const Footer = dynamic(() => import('@/components/Footer/Footer'), { ssr: false });
 interface MeetingPageProps {
   params: {
     lng: string;

--- a/src/app/[lng]/(main)/meeting/participate/page.tsx
+++ b/src/app/[lng]/(main)/meeting/participate/page.tsx
@@ -8,11 +8,12 @@ import {
   getMeetingRejected,
   getMeetingWaiting,
 } from '@/apis/meeting';
-import { Footer } from '@/components/Footer';
 import { Loading } from '@/components/Loading';
 import { HydrationProvider } from '@/components/Provider';
+import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
 
+const Footer = dynamic(() => import('@/components/Footer/Footer.server'), { ssr: false });
 interface MeetingPageProps {
   params: {
     lng: string;

--- a/src/app/[lng]/(sub)/join/funnels/step1/components/NumberVerifyForm.client.tsx
+++ b/src/app/[lng]/(sub)/join/funnels/step1/components/NumberVerifyForm.client.tsx
@@ -10,6 +10,7 @@ import { TextFieldController } from '@/components/TextField';
 import { regexr } from '@/constants/regexr';
 import useAppRouter from '@/hooks/useAppRouter';
 import { setTokenAtCookie } from '@/utils/auth/tokenController';
+import sendMessageToReactNative from '@/utils/sendMessageToReactNative';
 
 import type { SignUpState } from '../../../type';
 import type { SubmitHandler } from 'react-hook-form';
@@ -72,6 +73,7 @@ export default function NumberVerifyForm({ setInputStatus }: NumberVerifyFormPro
                   return;
                 }
 
+                sendMessageToReactNative({ type: 'SIGN_IN', data: 'LOGIN_SUCCESS' });
                 await setTokenAtCookie({
                   accessToken: response.token.accessToken,
                   refreshToken: response.token.refreshToken,

--- a/src/app/[lng]/not-found.tsx
+++ b/src/app/[lng]/not-found.tsx
@@ -1,7 +1,7 @@
 import NoMeeting from './(main)/meeting/components/NoMeeting';
 import dynamic from 'next/dynamic';
 
-const Footer = dynamic(() => import('@/components/Footer/Footer.server'), { ssr: false });
+const Footer = dynamic(() => import('@/components/Footer/Footer'), { ssr: false });
 
 export default function NotFound() {
   return (

--- a/src/app/[lng]/not-found.tsx
+++ b/src/app/[lng]/not-found.tsx
@@ -1,5 +1,7 @@
 import NoMeeting from './(main)/meeting/components/NoMeeting';
-import { Footer } from '@/components/Footer';
+import dynamic from 'next/dynamic';
+
+const Footer = dynamic(() => import('@/components/Footer/Footer.server'), { ssr: false });
 
 export default function NotFound() {
   return (

--- a/src/components/Footer/Footer.server.tsx
+++ b/src/components/Footer/Footer.server.tsx
@@ -1,10 +1,10 @@
-import Link from 'next/link';
-
 import { ButtonAnimation } from '../Animation';
 import { Icon } from '../Icon';
 import { NavLink } from '../NavLink';
 import { serverTranslation } from '@/app/i18n';
 import cn from '@/utils/cn';
+import { getIsApp } from '@/utils/getIsApp';
+import Link from 'next/link';
 
 import type { PageType } from '@/types';
 
@@ -53,30 +53,34 @@ export default async function Footer({ lng, page, isSpacing = true, spacingColor
   const { t } = await serverTranslation(lng, 'common');
   const isSelected = (tab: TabType) => tab.name === page;
 
-  return (
-    <>
-      <footer className="fixed inset-x-0 bottom-0 mx-auto flex max-w-450 touch-pan-x rounded-t-24 bg-white pb-8 pt-12 shadow-navigation">
-        {tabList.map((tab: TabType) => (
-          <ButtonAnimation
-            key={tab.id}
-            className={cn('flex w-full flex-col text-center text-caption', {
-              'text-sign-brand': isSelected(tab),
-              'text-sign-tertiary': !isSelected(tab),
-            })}
-          >
-            <NavLink isReplace href={tab.url} scroll={false}>
-              <Icon
-                id={`32-footer-${tab.name}${isSelected(tab) ? '_selected' : '_default'}`}
-                width={32}
-                height={32}
-                className="mx-auto"
-              />
-              <p>{t(tab.name)}</p>
-            </NavLink>
-          </ButtonAnimation>
-        ))}
-      </footer>
-      {isSpacing && <div className="h-70" style={{ backgroundColor: spacingColor }} />}
-    </>
-  );
+  const isApp = getIsApp();
+
+  if (isApp) return null;
+  else
+    return (
+      <>
+        <footer className="fixed inset-x-0 bottom-0 mx-auto flex max-w-450 touch-pan-x rounded-t-24 bg-white pb-8 pt-12 shadow-navigation">
+          {tabList.map((tab: TabType) => (
+            <ButtonAnimation
+              key={tab.id}
+              className={cn('flex w-full flex-col text-center text-caption', {
+                'text-sign-brand': isSelected(tab),
+                'text-sign-tertiary': !isSelected(tab),
+              })}
+            >
+              <NavLink isReplace href={tab.url} scroll={false}>
+                <Icon
+                  id={`32-footer-${tab.name}${isSelected(tab) ? '_selected' : '_default'}`}
+                  width={32}
+                  height={32}
+                  className="mx-auto"
+                />
+                <p>{t(tab.name)}</p>
+              </NavLink>
+            </ButtonAnimation>
+          ))}
+        </footer>
+        {isSpacing && <div className="h-70" style={{ backgroundColor: spacingColor }} />}
+      </>
+    );
 }

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,10 +1,11 @@
+'use client';
 import { ButtonAnimation } from '../Animation';
 import { Icon } from '../Icon';
 import { NavLink } from '../NavLink';
-import { serverTranslation } from '@/app/i18n';
 import cn from '@/utils/cn';
-import { getIsApp } from '@/utils/getIsApp';
-import Link from 'next/link';
+import { getIsAndroid } from '@/utils/getIsAndroid';
+import { getIsIOS } from '@/utils/getIsIOS';
+import { useTranslation } from 'react-i18next';
 
 import type { PageType } from '@/types';
 
@@ -49,13 +50,14 @@ interface FooterProps {
   spacingColor?: string;
 }
 
-export default async function Footer({ lng, page, isSpacing = true, spacingColor }: FooterProps) {
-  const { t } = await serverTranslation(lng, 'common');
+export default function Footer({ page, isSpacing = true, spacingColor }: FooterProps) {
+  const { t } = useTranslation('common');
   const isSelected = (tab: TabType) => tab.name === page;
 
-  const isApp = getIsApp();
+  const isIOS = getIsIOS();
+  const isAndroid = getIsAndroid();
 
-  if (isApp) return null;
+  if (isIOS || isAndroid) return null;
   else
     return (
       <>

--- a/src/components/Footer/index.ts
+++ b/src/components/Footer/index.ts
@@ -1,1 +1,1 @@
-export { default as Footer } from './Footer.server';
+export { default as Footer } from './Footer';

--- a/src/utils/getIsAndroid.ts
+++ b/src/utils/getIsAndroid.ts
@@ -1,0 +1,8 @@
+import { getIsServer } from './getIsServer';
+
+export const getIsAndroid = () => {
+  const isServer = getIsServer();
+  if (isServer) return false;
+
+  return navigator.userAgent.match(/Android/i) != null;
+};

--- a/src/utils/getIsApp.ts
+++ b/src/utils/getIsApp.ts
@@ -1,10 +1,11 @@
-import { getIsAndroid } from './getIsAndroid';
-import { getIsIOS } from './getIsIOS';
+import { getIsServer } from './getIsServer';
 
 export const getIsApp = () => {
-  const isIOS = getIsIOS();
-  const isAndroid = getIsAndroid();
-  if (isIOS || isAndroid) return true;
+  let isApp = false;
+  const isServer = getIsServer();
 
-  return false;
+  if (!isServer && window.ReactNativeWebView) {
+    isApp = true;
+  }
+  return isApp;
 };

--- a/src/utils/getIsApp.ts
+++ b/src/utils/getIsApp.ts
@@ -1,7 +1,10 @@
+import { getIsAndroid } from './getIsAndroid';
+import { getIsIOS } from './getIsIOS';
+
 export const getIsApp = () => {
-  let isApp = false;
-  if (typeof window !== 'undefined' && window.ReactNativeWebView) {
-    isApp = true;
-  }
-  return isApp;
+  const isIOS = getIsIOS();
+  const isAndroid = getIsAndroid();
+  if (isIOS || isAndroid) return true;
+
+  return false;
 };

--- a/src/utils/getIsIOS.ts
+++ b/src/utils/getIsIOS.ts
@@ -1,0 +1,8 @@
+import { getIsServer } from './getIsServer';
+
+export const getIsIOS = () => {
+  const isServer = getIsServer();
+  if (isServer) return false;
+
+  return navigator.userAgent.match(/ipad|iphone/i) != null;
+};

--- a/src/utils/getIsServer.ts
+++ b/src/utils/getIsServer.ts
@@ -1,0 +1,1 @@
+export const getIsServer = () => typeof window === 'undefined' && typeof global !== 'undefined';


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 신규 피처
- close #593 

## 💁 무엇이 어떻게 바뀌나요?

1. Footer를 제거하고, 로그인 시 RN의 TabBar를 적용하도록 구현하였습니다.

RN에서는 현재 Staging에 Code Push를 해서 개발 환경에서 테스트가 가능합니다.

얼른 모노레포를 적용해서 RN과 Next를 한 레포에서 관리하고 싶네요 ㅜㅜ

[개발 문서](https://www.notion.so/guesung/React-Native-Navigation-446a0886166c4b3c83b976c277ae46c4?pvs=4)에 아직 전부 작성하지는 않았지만, TabBar 사용 전과 후를 비교한 영상 첨부해두었습니다.

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
