### PR TITLE
Fix: Multiple image uploader 컴포넌트가 여러장을 선택 못 하는 버그 수정

### DIFF
--- a/packages/web/src/components/Image/MultiImageUploader.tsx
+++ b/packages/web/src/components/Image/MultiImageUploader.tsx
@@ -23,9 +23,12 @@ export default function MultiImageUploader<T extends FieldValues>({
     control,
   });
 
-  const { handleFileUploadClick, isPending } = useFileUpload((files) => {
-    onChange([...value, ...files]);
-  });
+  const { handleFileUploadClick, isPending } = useFileUpload(
+    (files) => {
+      onChange([...value, ...files]);
+    },
+    { multiple: true }
+  );
 
   const handleDeleteClick = useCallback(
     (imageUrl: string) => onChange(value.filter((v: string) => v !== imageUrl)),


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

- 신규 피처
- #654 
## 💁 무엇이 어떻게 바뀌나요?

useFileUploader 훅에 전달하는 option이 누락되었던 버그였습니다. 8a3e3f83a402dc6098dc2c95d708256987ba38cd

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
